### PR TITLE
[Feat-3] 쿠폰 발급 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,18 @@ dependencies {
 
 	implementation 'com.auth0:java-jwt:4.4.0'
 
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.17.7'
+//	implementation 'io.lettuce.core:lettuce-core'
+
+
 	//유효성
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	//prometheus
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/personal_project/coupon/coupon/application/inputport/IssueCouponInputPort.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/inputport/IssueCouponInputPort.java
@@ -1,0 +1,75 @@
+package com.personal_project.coupon.coupon.application.inputport;
+
+import com.personal_project.coupon.coupon.application.outputport.CouponIssueOutPort;
+import com.personal_project.coupon.coupon.application.outputport.CouponOutPort;
+import com.personal_project.coupon.coupon.application.outputport.EventOutport;
+import com.personal_project.coupon.coupon.application.usercase.IssueCoupon;
+import com.personal_project.coupon.coupon.domain.Coupon;
+import com.personal_project.coupon.coupon.domain.CouponIssue;
+import com.personal_project.coupon.coupon.domain.Event;
+import com.personal_project.coupon.global.exception.BusinessException;
+import com.personal_project.coupon.global.exception.errorcode.CommonErrorCode;
+import com.personal_project.coupon.member.applicaion.outputport.MemberOutputPort;
+import com.personal_project.coupon.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class IssueCouponInputPort implements IssueCoupon {
+
+    private final MemberOutputPort memberOutputPort;
+    private final EventOutport eventOutport;
+    private final CouponOutPort couponOutPort;
+    private final CouponIssueOutPort couponIssueOutPort;
+
+    @Override
+    @Transactional
+    public void issue(Long eventId, Long couponId, Long memberId){
+        //유저 조회
+        Member member = memberOutputPort.findById(memberId).orElseThrow(()-> new BusinessException(CommonErrorCode.USER_EMAIL_NOT_FOUND));
+
+        //이벤트 조회
+        Event event = eventOutport.findById(eventId).orElseThrow(()-> new BusinessException(CommonErrorCode.EVENT_NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now();
+        System.out.println(now);
+
+        // 이벤트 기간 및 발급 가능 시간 체크
+        if(!event.isEventActive(now)){
+            throw new BusinessException(CommonErrorCode.EVENT_NOT_ACTIVE);
+        }
+        //쿠폰 조회
+        Coupon coupon = couponOutPort.findById(couponId).orElseThrow(()-> new BusinessException(CommonErrorCode.COUPON_NOT_FOUND));
+
+        //해당 쿠폰 발급 가능 기간 체크
+        if(!coupon.isIssuable(now)){
+            throw new BusinessException(CommonErrorCode.COUPON_NOT_ACTIVE);
+        }
+
+        //해당 쿠폰 재고 부족
+        if(!coupon.isQuantity()){
+            throw new BusinessException(CommonErrorCode.COUPON_OUT_OF_STOCK);
+        }
+
+        //해당 유저가 쿠폰을 중복해서 가지는지
+       if(couponIssueOutPort.existByUserIdAndCouponId(memberId, couponId)){
+           throw new BusinessException(CommonErrorCode.COUPON_ALREADY_ISSUED);
+       }
+
+       CouponIssue couponIssue = CouponIssue.create(member,coupon,now);
+
+       //히스토리 추가
+       couponIssueOutPort.save(couponIssue);
+
+       //재고 증가
+       coupon.increaseStock();
+    }
+
+}

--- a/src/main/java/com/personal_project/coupon/coupon/application/inputport/IssueCouponInputPort.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/inputport/IssueCouponInputPort.java
@@ -1,25 +1,25 @@
 package com.personal_project.coupon.coupon.application.inputport;
 
-import com.personal_project.coupon.coupon.application.usercase.CouponIssue;
+import com.personal_project.coupon.coupon.application.usercase.IssueCoupon;
 import com.personal_project.coupon.coupon.application.usercase.CouponIssueFacade;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 
-@Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
 @Slf4j
-@Qualifier("PessimisticLockCouponIssue")
-public class IssueCouponInputPort implements CouponIssue {
+@Service
+public class IssueCouponInputPort implements IssueCoupon {
 
     private final CouponIssueFacade couponIssueFacade;
 
+    @Autowired
+    public IssueCouponInputPort(@Qualifier("pessimisticLockCouponIssue") CouponIssueFacade couponIssueFacade) {
+        this.couponIssueFacade = couponIssueFacade;
+    }
+
     @Override
-    @Transactional
     public void issue(Long eventId, Long couponId, Long memberId) {
         // 로직에 따라 락을 다르게 선택
         couponIssueFacade.issueCoupon(eventId, couponId, memberId);

--- a/src/main/java/com/personal_project/coupon/coupon/application/inputport/IssueCouponInputPort.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/inputport/IssueCouponInputPort.java
@@ -15,7 +15,7 @@ public class IssueCouponInputPort implements IssueCoupon {
     private final CouponIssueFacade couponIssueFacade;
 
     @Autowired
-    public IssueCouponInputPort(@Qualifier("pessimisticLockCouponIssue") CouponIssueFacade couponIssueFacade) {
+    public IssueCouponInputPort(@Qualifier("redissonLockCouponIssue") CouponIssueFacade couponIssueFacade) {
         this.couponIssueFacade = couponIssueFacade;
     }
 

--- a/src/main/java/com/personal_project/coupon/coupon/application/inputport/IssueCouponInputPort.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/inputport/IssueCouponInputPort.java
@@ -1,75 +1,28 @@
 package com.personal_project.coupon.coupon.application.inputport;
 
-import com.personal_project.coupon.coupon.application.outputport.CouponIssueOutPort;
-import com.personal_project.coupon.coupon.application.outputport.CouponOutPort;
-import com.personal_project.coupon.coupon.application.outputport.EventOutport;
-import com.personal_project.coupon.coupon.application.usercase.IssueCoupon;
-import com.personal_project.coupon.coupon.domain.Coupon;
-import com.personal_project.coupon.coupon.domain.CouponIssue;
-import com.personal_project.coupon.coupon.domain.Event;
-import com.personal_project.coupon.global.exception.BusinessException;
-import com.personal_project.coupon.global.exception.errorcode.CommonErrorCode;
-import com.personal_project.coupon.member.applicaion.outputport.MemberOutputPort;
-import com.personal_project.coupon.member.domain.Member;
+import com.personal_project.coupon.coupon.application.usercase.CouponIssue;
+import com.personal_project.coupon.coupon.application.usercase.CouponIssueFacade;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Slf4j
-public class IssueCouponInputPort implements IssueCoupon {
+@Qualifier("PessimisticLockCouponIssue")
+public class IssueCouponInputPort implements CouponIssue {
 
-    private final MemberOutputPort memberOutputPort;
-    private final EventOutport eventOutport;
-    private final CouponOutPort couponOutPort;
-    private final CouponIssueOutPort couponIssueOutPort;
+    private final CouponIssueFacade couponIssueFacade;
 
     @Override
     @Transactional
-    public void issue(Long eventId, Long couponId, Long memberId){
-        //유저 조회
-        Member member = memberOutputPort.findById(memberId).orElseThrow(()-> new BusinessException(CommonErrorCode.USER_EMAIL_NOT_FOUND));
-
-        //이벤트 조회
-        Event event = eventOutport.findById(eventId).orElseThrow(()-> new BusinessException(CommonErrorCode.EVENT_NOT_FOUND));
-
-        LocalDateTime now = LocalDateTime.now();
-        System.out.println(now);
-
-        // 이벤트 기간 및 발급 가능 시간 체크
-        if(!event.isEventActive(now)){
-            throw new BusinessException(CommonErrorCode.EVENT_NOT_ACTIVE);
-        }
-        //쿠폰 조회
-        Coupon coupon = couponOutPort.findById(couponId).orElseThrow(()-> new BusinessException(CommonErrorCode.COUPON_NOT_FOUND));
-
-        //해당 쿠폰 발급 가능 기간 체크
-        if(!coupon.isIssuable(now)){
-            throw new BusinessException(CommonErrorCode.COUPON_NOT_ACTIVE);
-        }
-
-        //해당 쿠폰 재고 부족
-        if(!coupon.isQuantity()){
-            throw new BusinessException(CommonErrorCode.COUPON_OUT_OF_STOCK);
-        }
-
-        //해당 유저가 쿠폰을 중복해서 가지는지
-       if(couponIssueOutPort.existByUserIdAndCouponId(memberId, couponId)){
-           throw new BusinessException(CommonErrorCode.COUPON_ALREADY_ISSUED);
-       }
-
-       CouponIssue couponIssue = CouponIssue.create(member,coupon,now);
-
-       //히스토리 추가
-       couponIssueOutPort.save(couponIssue);
-
-       //재고 증가
-       coupon.increaseStock();
+    public void issue(Long eventId, Long couponId, Long memberId) {
+        // 로직에 따라 락을 다르게 선택
+        couponIssueFacade.issueCoupon(eventId, couponId, memberId);
     }
 
 }

--- a/src/main/java/com/personal_project/coupon/coupon/application/outputport/CouponIssueOutPort.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/outputport/CouponIssueOutPort.java
@@ -1,0 +1,9 @@
+package com.personal_project.coupon.coupon.application.outputport;
+
+import com.personal_project.coupon.coupon.domain.CouponIssue;
+
+public interface CouponIssueOutPort {
+    boolean existByUserIdAndCouponId(Long memberId,Long couponId);
+
+    CouponIssue save(CouponIssue couponIssue);
+}

--- a/src/main/java/com/personal_project/coupon/coupon/application/outputport/CouponOutPort.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/outputport/CouponOutPort.java
@@ -1,0 +1,10 @@
+package com.personal_project.coupon.coupon.application.outputport;
+
+import com.personal_project.coupon.coupon.domain.Coupon;
+
+import java.util.Optional;
+
+public interface CouponOutPort {
+
+    Optional<Coupon> findById(Long couponId);
+}

--- a/src/main/java/com/personal_project/coupon/coupon/application/outputport/CouponOutPort.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/outputport/CouponOutPort.java
@@ -7,4 +7,14 @@ import java.util.Optional;
 public interface CouponOutPort {
 
     Optional<Coupon> findById(Long couponId);
+
+    void save(Coupon coupon);
+
+    Optional<Coupon> findByIdWithLock(Long couponId);
+
+    void getLock(String key);
+
+    void releaseLock(String key);
+
+
 }

--- a/src/main/java/com/personal_project/coupon/coupon/application/outputport/EventOutport.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/outputport/EventOutport.java
@@ -1,0 +1,10 @@
+package com.personal_project.coupon.coupon.application.outputport;
+
+import com.personal_project.coupon.coupon.domain.Event;
+
+import java.util.Optional;
+
+public interface EventOutport {
+
+    Optional<Event> findById(Long eventId);
+}

--- a/src/main/java/com/personal_project/coupon/coupon/application/service/DefaultCouponIssue.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/service/DefaultCouponIssue.java
@@ -3,7 +3,6 @@ package com.personal_project.coupon.coupon.application.service;
 import com.personal_project.coupon.coupon.application.outputport.CouponIssueOutPort;
 import com.personal_project.coupon.coupon.application.outputport.CouponOutPort;
 import com.personal_project.coupon.coupon.application.outputport.EventOutport;
-import com.personal_project.coupon.coupon.application.usercase.CouponIssueFacade;
 import com.personal_project.coupon.coupon.domain.Coupon;
 import com.personal_project.coupon.coupon.domain.CouponIssue;
 import com.personal_project.coupon.coupon.domain.Event;
@@ -21,14 +20,13 @@ import java.time.LocalDateTime;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class PessimisticLockCouponIssue implements CouponIssueFacade {
+public class DefaultCouponIssue {
 
     private final MemberOutputPort memberOutputPort;
     private final EventOutport eventOutport;
     private final CouponOutPort couponOutPort;
     private final CouponIssueOutPort couponIssueOutPort;
 
-    @Override
     @Transactional
     public void issueCoupon(Long eventId, Long couponId, Long memberId){
         //유저 조회
@@ -45,9 +43,8 @@ public class PessimisticLockCouponIssue implements CouponIssueFacade {
             throw new BusinessException(CommonErrorCode.EVENT_NOT_ACTIVE);
         }
 
-        // 배타 락으로 쿠폰 조회
-        Coupon coupon = couponOutPort.findByIdWithLock(couponId)
-                .orElseThrow(() -> new BusinessException(CommonErrorCode.COUPON_NOT_FOUND));
+        //쿠폰 조회
+        Coupon coupon = couponOutPort.findById(couponId).orElseThrow(()-> new BusinessException(CommonErrorCode.COUPON_NOT_FOUND));
 
         //해당 쿠폰 발급 가능 기간 체크
         if(!coupon.isIssuable(now)){
@@ -72,5 +69,4 @@ public class PessimisticLockCouponIssue implements CouponIssueFacade {
         //재고 증가
         coupon.increaseStock();
     }
-
 }

--- a/src/main/java/com/personal_project/coupon/coupon/application/service/LettuceLockCouponIssue.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/service/LettuceLockCouponIssue.java
@@ -1,0 +1,35 @@
+package com.personal_project.coupon.coupon.application.service;
+
+import com.personal_project.coupon.coupon.application.usercase.CouponIssueFacade;
+import com.personal_project.coupon.global.infrastructure.redis.RedisLockManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LettuceLockCouponIssue implements CouponIssueFacade {
+
+    private final DefaultCouponIssue defaultCouponIssue;
+    private final RedisLockManager redisLockManager;
+    private static final String LOCK_PREFIX = "LOCK:COUPON:"; // 락을 위한 키 접두어
+
+    @Override
+    public void issueCoupon(Long eventId, Long couponId, Long memberId) {
+        String lockKey = LOCK_PREFIX + couponId; // 쿠폰 ID를 락 키로 사용
+
+        Boolean lockAcquired = redisLockManager.lock(lockKey); // 락 시도
+        if (!lockAcquired) {
+            throw new RuntimeException("쿠폰 발급 중 중복 요청이 발생했습니다. 잠시 후 다시 시도해주세요.");
+        }
+
+        try {
+            defaultCouponIssue.issueCoupon(eventId, couponId, memberId);
+        } finally {
+            redisLockManager.unlock(lockKey); // 작업 완료 후 락 해제
+        }
+    }
+
+}

--- a/src/main/java/com/personal_project/coupon/coupon/application/service/NamedLockCouponIssue.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/service/NamedLockCouponIssue.java
@@ -1,0 +1,32 @@
+package com.personal_project.coupon.coupon.application.service;
+
+import com.personal_project.coupon.coupon.application.outputport.CouponOutPort;
+import com.personal_project.coupon.coupon.application.usercase.CouponIssueFacade;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NamedLockCouponIssue implements CouponIssueFacade {
+    private final CouponOutPort couponOutPort;
+    private final DefaultCouponIssue defaultCouponIssue;
+
+    @Override
+    public void issueCoupon(Long eventId, Long couponId, Long memberId) {
+        String lockKey = "coupon_" + couponId;
+
+        try {
+            log.info("Acquiring Named Lock: {}", lockKey);
+            couponOutPort.getLock(lockKey); // 네임드 락 획득
+
+            // 기본 쿠폰 발급 로직 실행
+            defaultCouponIssue.issueCoupon(eventId, couponId, memberId);
+
+        } finally {
+            log.info("Releasing Named Lock: {}", lockKey);
+            couponOutPort.releaseLock(lockKey); // 네임드 락 해제
+        }
+    }
+}

--- a/src/main/java/com/personal_project/coupon/coupon/application/service/PessimisticLockCouponIssue.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/service/PessimisticLockCouponIssue.java
@@ -1,0 +1,72 @@
+package com.personal_project.coupon.coupon.application.service;
+
+import com.personal_project.coupon.coupon.application.outputport.CouponIssueOutPort;
+import com.personal_project.coupon.coupon.application.outputport.CouponOutPort;
+import com.personal_project.coupon.coupon.application.outputport.EventOutport;
+import com.personal_project.coupon.coupon.application.usercase.CouponIssueFacade;
+import com.personal_project.coupon.coupon.domain.Coupon;
+import com.personal_project.coupon.coupon.domain.Event;
+import com.personal_project.coupon.global.exception.BusinessException;
+import com.personal_project.coupon.global.exception.errorcode.CommonErrorCode;
+import com.personal_project.coupon.member.applicaion.outputport.MemberOutputPort;
+import com.personal_project.coupon.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class PessimisticLockCouponIssue implements CouponIssueFacade {
+
+    private final MemberOutputPort memberOutputPort;
+    private final EventOutport eventOutport;
+    private final CouponOutPort couponOutPort;
+    private final CouponIssueOutPort couponIssueOutPort;
+
+    @Override
+    public void issueCoupon(Long eventId, Long couponId, Long memberId){
+        //유저 조회
+        Member member = memberOutputPort.findById(memberId).orElseThrow(()-> new BusinessException(CommonErrorCode.USER_EMAIL_NOT_FOUND));
+
+        //이벤트 조회
+        Event event = eventOutport.findById(eventId).orElseThrow(()-> new BusinessException(CommonErrorCode.EVENT_NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now();
+        System.out.println(now);
+
+        // 이벤트 기간 및 발급 가능 시간 체크
+        if(!event.isEventActive(now)){
+            throw new BusinessException(CommonErrorCode.EVENT_NOT_ACTIVE);
+        }
+
+        //쿠폰 조회
+        Coupon coupon = couponOutPort.findById(couponId).orElseThrow(()-> new BusinessException(CommonErrorCode.COUPON_NOT_FOUND));
+
+        //해당 쿠폰 발급 가능 기간 체크
+        if(!coupon.isIssuable(now)){
+            throw new BusinessException(CommonErrorCode.COUPON_NOT_ACTIVE);
+        }
+
+        //해당 쿠폰 재고 부족
+        if(!coupon.isQuantity()){
+            throw new BusinessException(CommonErrorCode.COUPON_OUT_OF_STOCK);
+        }
+
+        //해당 유저가 쿠폰을 중복해서 가지는지
+        if(couponIssueOutPort.existByUserIdAndCouponId(memberId, couponId)){
+            throw new BusinessException(CommonErrorCode.COUPON_ALREADY_ISSUED);
+        }
+
+        com.personal_project.coupon.coupon.domain.CouponIssue couponIssue = com.personal_project.coupon.coupon.domain.CouponIssue.create(member,coupon,now);
+
+        //히스토리 추가
+        couponIssueOutPort.save(couponIssue);
+
+        //재고 증가
+        coupon.increaseStock();
+    }
+
+}

--- a/src/main/java/com/personal_project/coupon/coupon/application/service/RedissonLockCouponIssue.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/service/RedissonLockCouponIssue.java
@@ -1,0 +1,22 @@
+package com.personal_project.coupon.coupon.application.service;
+
+import com.personal_project.coupon.coupon.application.usercase.CouponIssueFacade;
+import com.personal_project.coupon.global.annotation.DistributedLock;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedissonLockCouponIssue implements CouponIssueFacade {
+
+    private final DefaultCouponIssue defaultCouponIssue;
+
+    @Override
+    @DistributedLock(value = "couponId:#couponId")
+    public void issueCoupon(Long eventId, Long couponId, Long memberId) {
+        defaultCouponIssue.issueCoupon(eventId, couponId, memberId);
+    }
+
+}

--- a/src/main/java/com/personal_project/coupon/coupon/application/usercase/CouponIssue.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/usercase/CouponIssue.java
@@ -1,6 +1,6 @@
 package com.personal_project.coupon.coupon.application.usercase;
 
-public interface IssueCoupon {
+public interface CouponIssue {
 
     void issue(Long eventId, Long couponId, Long memberId);
 }

--- a/src/main/java/com/personal_project/coupon/coupon/application/usercase/CouponIssueFacade.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/usercase/CouponIssueFacade.java
@@ -1,0 +1,5 @@
+package com.personal_project.coupon.coupon.application.usercase;
+
+public interface CouponIssueFacade {
+    void issueCoupon(Long eventId, Long couponId, Long memberId);
+}

--- a/src/main/java/com/personal_project/coupon/coupon/application/usercase/IssueCoupon.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/usercase/IssueCoupon.java
@@ -1,0 +1,6 @@
+package com.personal_project.coupon.coupon.application.usercase;
+
+public interface IssueCoupon {
+
+    void issue(Long eventId, Long couponId, Long memberId);
+}

--- a/src/main/java/com/personal_project/coupon/coupon/application/usercase/IssueCoupon.java
+++ b/src/main/java/com/personal_project/coupon/coupon/application/usercase/IssueCoupon.java
@@ -1,6 +1,6 @@
 package com.personal_project.coupon.coupon.application.usercase;
 
-public interface CouponIssue {
+public interface IssueCoupon {
 
     void issue(Long eventId, Long couponId, Long memberId);
 }

--- a/src/main/java/com/personal_project/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/com/personal_project/coupon/coupon/domain/Coupon.java
@@ -32,6 +32,8 @@ public class Coupon extends BaseEntity {
 
     private Integer maxQuantity;
 
+    private Integer issuedQuantity;
+
     private LocalDateTime startTime; //쿠폰 발행 시작 시간
 
     private LocalDateTime endTime; //쿠폰 발행 종료 시간
@@ -43,4 +45,15 @@ public class Coupon extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private CouponStatus Couponstatus; //발급전 , 발급됨
 
+    public boolean isIssuable(LocalDateTime nowTime) {
+        return (nowTime.isAfter(event.getStartDate()) && nowTime.isBefore(event.getEndDate()));
+    }
+
+    public boolean isQuantity() {
+        return issuedQuantity < maxQuantity;
+    }
+
+    public void increaseStock() {
+        issuedQuantity++;
+    }
 }

--- a/src/main/java/com/personal_project/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/com/personal_project/coupon/coupon/domain/Coupon.java
@@ -1,0 +1,46 @@
+package com.personal_project.coupon.coupon.domain;
+
+
+import com.personal_project.coupon.coupon.domain.enumeration.CouponStatus;
+import com.personal_project.coupon.coupon.domain.enumeration.DiscountType;
+import com.personal_project.coupon.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "coupon_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
+
+    @Enumerated(EnumType.STRING)
+    private DiscountType discountType;
+
+    private Integer discountValue;
+
+    private Integer maxQuantity;
+
+    private LocalDateTime startTime; //쿠폰 발행 시작 시간
+
+    private LocalDateTime endTime; //쿠폰 발행 종료 시간
+
+    private LocalDateTime usageStartTime; //쿠폰 사용 가능 시작 시간
+
+    private LocalDateTime usageEndTime; //쿠폰 사용 가능 종료 시간
+
+    @Enumerated(EnumType.STRING)
+    private CouponStatus Couponstatus; //발급전 , 발급됨
+
+}

--- a/src/main/java/com/personal_project/coupon/coupon/domain/CouponIssue.java
+++ b/src/main/java/com/personal_project/coupon/coupon/domain/CouponIssue.java
@@ -31,7 +31,15 @@ public class CouponIssue extends BaseEntity {
     private LocalDateTime issuedAt; //발급시간
 
     @Enumerated(EnumType.STRING)
-    private CouponIssueStatus CouponIssueStatus;     //발급됨, 사용됨
+    private CouponIssueStatus couponIssueStatus;     //발급됨, 사용됨
 
+    public static CouponIssue create(Member member,Coupon coupon, LocalDateTime now){
+        return CouponIssue.builder()
+                .member(member)
+                .coupon(coupon)
+                .issuedAt(now)
+                .couponIssueStatus(CouponIssueStatus.ISSUED)
+                .build();
+    }
 
 }

--- a/src/main/java/com/personal_project/coupon/coupon/domain/CouponIssue.java
+++ b/src/main/java/com/personal_project/coupon/coupon/domain/CouponIssue.java
@@ -1,0 +1,37 @@
+package com.personal_project.coupon.coupon.domain;
+
+import com.personal_project.coupon.coupon.domain.enumeration.CouponIssueStatus;
+import com.personal_project.coupon.global.entity.BaseEntity;
+import com.personal_project.coupon.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponIssue extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "coupon_issue_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id")
+    private Coupon coupon;
+
+    private LocalDateTime issuedAt; //발급시간
+
+    @Enumerated(EnumType.STRING)
+    private CouponIssueStatus CouponIssueStatus;     //발급됨, 사용됨
+
+
+}

--- a/src/main/java/com/personal_project/coupon/coupon/domain/CouponUseRestrict.java
+++ b/src/main/java/com/personal_project/coupon/coupon/domain/CouponUseRestrict.java
@@ -1,0 +1,4 @@
+package com.personal_project.coupon.coupon.domain;
+
+public class CouponUseRestrict {
+}

--- a/src/main/java/com/personal_project/coupon/coupon/domain/Event.java
+++ b/src/main/java/com/personal_project/coupon/coupon/domain/Event.java
@@ -1,0 +1,35 @@
+package com.personal_project.coupon.coupon.domain;
+
+import com.personal_project.coupon.coupon.domain.enumeration.EventStatus;
+import com.personal_project.coupon.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Event extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "event_id")
+    private Long id;
+
+    private String name;
+
+    private LocalDateTime startDate; //이벤트 시작 시간
+
+    private LocalDateTime endDate; //이벤트 종료 시간
+
+    private LocalTime dailyStartDate; //매일 쿠폰 발급 시작 시간
+
+    private LocalTime dailyEndDate; //매일 쿠폰 발급 종료 시간
+
+    @Enumerated(EnumType.STRING)
+    private EventStatus eventStatus; //시작전, 시작, 마감
+}

--- a/src/main/java/com/personal_project/coupon/coupon/domain/Event.java
+++ b/src/main/java/com/personal_project/coupon/coupon/domain/Event.java
@@ -32,4 +32,14 @@ public class Event extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private EventStatus eventStatus; //시작전, 시작, 마감
+
+    public boolean isEventActive(LocalDateTime nowTime){
+        if (nowTime.isBefore(startDate) || nowTime.isAfter(endDate)) {
+            return false; // 이벤트 기간이 아닐 경우 비활성화
+        }
+        // 하루 중 특정 시간대 검사
+        LocalTime nowTimeOnly = nowTime.toLocalTime();
+        return nowTimeOnly.isAfter(dailyStartDate) && nowTimeOnly.isBefore(dailyEndDate);
+
+    }
 }

--- a/src/main/java/com/personal_project/coupon/coupon/domain/enumeration/CouponIssueStatus.java
+++ b/src/main/java/com/personal_project/coupon/coupon/domain/enumeration/CouponIssueStatus.java
@@ -1,0 +1,6 @@
+package com.personal_project.coupon.coupon.domain.enumeration;
+
+public enum CouponIssueStatus {
+    ISSUED, USED
+    //발급됨, 사용됨
+}

--- a/src/main/java/com/personal_project/coupon/coupon/domain/enumeration/CouponStatus.java
+++ b/src/main/java/com/personal_project/coupon/coupon/domain/enumeration/CouponStatus.java
@@ -1,0 +1,6 @@
+package com.personal_project.coupon.coupon.domain.enumeration;
+
+public enum CouponStatus {
+    PENDING, ISSUED
+    //발급전 , 발급됨
+}

--- a/src/main/java/com/personal_project/coupon/coupon/domain/enumeration/DiscountType.java
+++ b/src/main/java/com/personal_project/coupon/coupon/domain/enumeration/DiscountType.java
@@ -1,0 +1,6 @@
+package com.personal_project.coupon.coupon.domain.enumeration;
+
+public enum DiscountType {
+    PERCENTAGE, FIXED_AMOUNT, FREE_SHIPPING, FIRST_PURCHASE
+    //퍼센트, 정가할인, 무료배송, 첫 구매할인
+}

--- a/src/main/java/com/personal_project/coupon/coupon/domain/enumeration/EventStatus.java
+++ b/src/main/java/com/personal_project/coupon/coupon/domain/enumeration/EventStatus.java
@@ -1,0 +1,5 @@
+package com.personal_project.coupon.coupon.domain.enumeration;
+
+public enum EventStatus {
+    BEFORE, START, END
+}

--- a/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponAdapter.java
+++ b/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponAdapter.java
@@ -1,0 +1,20 @@
+package com.personal_project.coupon.coupon.framwork.jpaadapter;
+
+import com.personal_project.coupon.coupon.application.outputport.CouponOutPort;
+import com.personal_project.coupon.coupon.domain.Coupon;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponAdapter implements CouponOutPort {
+
+    private final CouponRepository couponRepository;
+    @Override
+    public Optional<Coupon> findById(Long couponId){
+        return couponRepository.findById(couponId);
+    }
+
+}

--- a/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponAdapter.java
+++ b/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponAdapter.java
@@ -12,9 +12,30 @@ import java.util.Optional;
 public class CouponAdapter implements CouponOutPort {
 
     private final CouponRepository couponRepository;
+    private final LockJpaRepository lockJpaRepository;
     @Override
     public Optional<Coupon> findById(Long couponId){
         return couponRepository.findById(couponId);
+    }
+
+    @Override
+    public void save(Coupon coupon){
+        couponRepository.save(coupon);
+    }
+
+    @Override
+    public Optional<Coupon> findByIdWithLock(Long couponId){
+        return couponRepository.findByIdWithLock(couponId);
+    }
+
+    @Override
+    public void getLock(String key){
+        lockJpaRepository.getLock(key);
+    }
+
+    @Override
+    public void releaseLock(String key){
+        lockJpaRepository.releaseLock(key);
     }
 
 }

--- a/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponIssueAdapter.java
+++ b/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponIssueAdapter.java
@@ -1,0 +1,24 @@
+package com.personal_project.coupon.coupon.framwork.jpaadapter;
+
+import com.personal_project.coupon.coupon.application.outputport.CouponIssueOutPort;
+import com.personal_project.coupon.coupon.domain.CouponIssue;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponIssueAdapter implements CouponIssueOutPort {
+
+    private final CouponIssueJpaRepository couponIssueJpaRepository;
+    @Override
+    public boolean existByUserIdAndCouponId(Long memberId,Long couponId){
+        return couponIssueJpaRepository.existsByMemberIdAndCouponId(memberId,couponId);
+    }
+
+    @Override
+    public CouponIssue save(CouponIssue couponIssue){
+        return couponIssueJpaRepository.save(couponIssue);
+    }
+
+
+}

--- a/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponIssueJpaRepository.java
+++ b/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponIssueJpaRepository.java
@@ -1,0 +1,12 @@
+package com.personal_project.coupon.coupon.framwork.jpaadapter;
+
+import com.personal_project.coupon.coupon.domain.CouponIssue;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CouponIssueJpaRepository extends JpaRepository<CouponIssue,Long> {
+
+    @Query("SELECT COUNT(c) > 0 FROM CouponIssue c WHERE c.member.id = :memberId AND c.coupon.id = :couponId")
+    boolean existsByMemberIdAndCouponId(@Param("memberId") Long memberId, @Param("couponId") Long couponId);
+}

--- a/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponRepository.java
+++ b/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponRepository.java
@@ -1,0 +1,8 @@
+package com.personal_project.coupon.coupon.framwork.jpaadapter;
+
+import com.personal_project.coupon.coupon.domain.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon,Long> {
+
+}

--- a/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponRepository.java
+++ b/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponRepository.java
@@ -4,11 +4,16 @@ import com.personal_project.coupon.coupon.domain.Coupon;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<Coupon,Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Coupon c WHERE c.id = :couponId")
+    Optional<Coupon> findByIdWithLock(@Param("couponId") Long couponId);
+
     Optional<Coupon> findById(Long couponId);
 }

--- a/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponRepository.java
+++ b/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/CouponRepository.java
@@ -1,8 +1,14 @@
 package com.personal_project.coupon.coupon.framwork.jpaadapter;
 
 import com.personal_project.coupon.coupon.domain.Coupon;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<Coupon,Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Coupon> findById(Long couponId);
 }

--- a/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/EventAdapter.java
+++ b/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/EventAdapter.java
@@ -1,0 +1,21 @@
+package com.personal_project.coupon.coupon.framwork.jpaadapter;
+
+import com.personal_project.coupon.coupon.application.outputport.EventOutport;
+import com.personal_project.coupon.coupon.domain.Event;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class EventAdapter implements EventOutport {
+
+    private final EventJpaRepository eventJpaRepository;
+
+    @Override
+    public Optional<Event> findById(Long eventId){
+        return eventJpaRepository.findById(eventId);
+    }
+
+}

--- a/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/EventJpaRepository.java
+++ b/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/EventJpaRepository.java
@@ -1,0 +1,8 @@
+package com.personal_project.coupon.coupon.framwork.jpaadapter;
+
+import com.personal_project.coupon.coupon.domain.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventJpaRepository extends JpaRepository<Event , Long> {
+
+}

--- a/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/LockJpaRepository.java
+++ b/src/main/java/com/personal_project/coupon/coupon/framwork/jpaadapter/LockJpaRepository.java
@@ -1,0 +1,13 @@
+package com.personal_project.coupon.coupon.framwork.jpaadapter;
+
+import com.personal_project.coupon.coupon.domain.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface LockJpaRepository extends JpaRepository<Coupon,Long> {
+    @Query(value = "select get_lock(:key, 3000)", nativeQuery = true)
+    void getLock(String key);
+
+    @Query(value = "select release_lock(:key)", nativeQuery = true)
+    void releaseLock(String key);
+}

--- a/src/main/java/com/personal_project/coupon/coupon/framwork/web/CouponController.java
+++ b/src/main/java/com/personal_project/coupon/coupon/framwork/web/CouponController.java
@@ -1,0 +1,23 @@
+package com.personal_project.coupon.coupon.framwork.web;
+
+import com.personal_project.coupon.coupon.application.usercase.IssueCoupon;
+import com.personal_project.coupon.global.exception.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/event")
+public class CouponController {
+
+    private final IssueCoupon issueCoupon;
+    @PostMapping("/{eventId}/issue")
+    public SuccessResponse<String> issue(@PathVariable Long eventId,
+                                         @RequestParam Long couponId,
+                                         @AuthenticationPrincipal Long memberId
+                                         ){
+        issueCoupon.issue(eventId,couponId,memberId);
+        return SuccessResponse.successWithoutResult("발급성공");
+    }
+}

--- a/src/main/java/com/personal_project/coupon/coupon/framwork/web/CouponController.java
+++ b/src/main/java/com/personal_project/coupon/coupon/framwork/web/CouponController.java
@@ -1,9 +1,8 @@
 package com.personal_project.coupon.coupon.framwork.web;
 
-import com.personal_project.coupon.coupon.application.usercase.IssueCoupon;
+import com.personal_project.coupon.coupon.application.usercase.CouponIssue;
 import com.personal_project.coupon.global.exception.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -11,13 +10,13 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/event")
 public class CouponController {
 
-    private final IssueCoupon issueCoupon;
+    private final CouponIssue couponIssue;
     @PostMapping("/{eventId}/issue")
     public SuccessResponse<String> issue(@PathVariable Long eventId,
                                          @RequestParam Long couponId,
-                                         @AuthenticationPrincipal Long memberId
+                                         @RequestParam Long memberId
                                          ){
-        issueCoupon.issue(eventId,couponId,memberId);
+        couponIssue.issue(eventId,couponId,memberId);
         return SuccessResponse.successWithoutResult("발급성공");
     }
 }

--- a/src/main/java/com/personal_project/coupon/coupon/framwork/web/CouponController.java
+++ b/src/main/java/com/personal_project/coupon/coupon/framwork/web/CouponController.java
@@ -1,6 +1,6 @@
 package com.personal_project.coupon.coupon.framwork.web;
 
-import com.personal_project.coupon.coupon.application.usercase.CouponIssue;
+import com.personal_project.coupon.coupon.application.usercase.IssueCoupon;
 import com.personal_project.coupon.global.exception.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/event")
 public class CouponController {
 
-    private final CouponIssue couponIssue;
+    private final IssueCoupon couponIssue;
     @PostMapping("/{eventId}/issue")
     public SuccessResponse<String> issue(@PathVariable Long eventId,
                                          @RequestParam Long couponId,

--- a/src/main/java/com/personal_project/coupon/global/annotation/DistributedLock.java
+++ b/src/main/java/com/personal_project/coupon/global/annotation/DistributedLock.java
@@ -1,0 +1,29 @@
+package com.personal_project.coupon.global.annotation;
+
+
+import java.lang.annotation.*;
+import java.util.concurrent.TimeUnit;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DistributedLock {
+
+    String value(); // Lock의 이름 (고유값)
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락을 기다리는 시간 (default - 5s)
+     * 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 임대 시간 (default - 3s)
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 2L;
+}

--- a/src/main/java/com/personal_project/coupon/global/aspect/DistributedLockAspect.java
+++ b/src/main/java/com/personal_project/coupon/global/aspect/DistributedLockAspect.java
@@ -1,0 +1,40 @@
+package com.personal_project.coupon.global.aspect;
+
+
+import com.personal_project.coupon.global.annotation.DistributedLock;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(distributedLock)")
+    public Object lockAround(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+
+        RLock lock = redissonClient.getLock(distributedLock.value());
+
+        try {
+            boolean isLocked = lock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            if (!isLocked) {
+                System.out.println("lock 획득 실패");
+                return false;
+            }
+            return joinPoint.proceed();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/src/main/java/com/personal_project/coupon/global/config/redis/RedisCacheConfig.java
+++ b/src/main/java/com/personal_project/coupon/global/config/redis/RedisCacheConfig.java
@@ -1,0 +1,34 @@
+package com.personal_project.coupon.global.config.redis;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@EnableCaching
+@Configuration
+public class RedisCacheConfig {
+    @Bean
+    public CacheManager oidcCacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration =
+                RedisCacheConfiguration.defaultCacheConfig()
+                        .serializeKeysWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new StringRedisSerializer()))
+                        .serializeValuesWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new GenericJackson2JsonRedisSerializer()));
+        // TTL 일주일로 설정
+//                        .entryTtl(Duration.ofDays(7L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/src/main/java/com/personal_project/coupon/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/personal_project/coupon/global/config/redis/RedisConfig.java
@@ -1,0 +1,49 @@
+package com.personal_project.coupon.global.config.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // 일반적인 key:value 의 경우 시리얼라이저
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+
+    //redsson 설정 분산락
+    @Bean
+    public RedissonClient redissonClient(){
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + host + ":" + port);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/personal_project/coupon/global/exception/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/personal_project/coupon/global/exception/errorcode/CommonErrorCode.java
@@ -29,7 +29,19 @@ public enum CommonErrorCode implements ErrorCode{
     USER_PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "4003", "비밀번호가 일치하지 않습니다."),
     LOGOUT_MEMBER(HttpStatus.FORBIDDEN, "3001", "로그아웃된 사용자입니다.(재 로그인 하세요."),
 
+
+    //event error(4101 ~ 4200)
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND,"4101","해당 이벤트를 찾을 수 없습니다."),
+    EVENT_NOT_ACTIVE(HttpStatus.NOT_FOUND,"4102","이벤트 기간이 아닙니다."),
+
+    //coupon error(4201 ~ 4300)
+    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND,"4201","해당 쿠폰를 찾을 수 없습니다."),
+    COUPON_NOT_ACTIVE(HttpStatus.NOT_FOUND,"4202","쿠폰 발급 기간이 아닙니다."),
+    COUPON_OUT_OF_STOCK(HttpStatus.NOT_FOUND,"4203", "쿠폰 재고가 부족합니다."),
+    COUPON_ALREADY_ISSUED(HttpStatus.BAD_REQUEST, "4204", "이미 쿠폰을 발급받았습니다.");
     ;
+
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/personal_project/coupon/global/infrastructure/redis/RedisLockManager.java
+++ b/src/main/java/com/personal_project/coupon/global/infrastructure/redis/RedisLockManager.java
@@ -1,0 +1,34 @@
+package com.personal_project.coupon.global.infrastructure.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RedisLockManager {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public Boolean lock(Object key) {
+        int retryCount = 5;
+        while (retryCount-- > 0) {
+            if (redisTemplate.opsForValue().setIfAbsent(key.toString(), "lock", Duration.ofMillis(5000))) {
+                return true;
+            }
+            try {
+                Thread.sleep(100); // 100ms 대기 후 재시도
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        return false; // 최대 시도 횟수를 넘었을 경우 false 반환
+    }
+
+    public Boolean unlock(Object key) {
+        return redisTemplate.delete(key.toString());
+    }
+
+}

--- a/src/main/java/com/personal_project/coupon/member/applicaion/usecase/AuthMember.java
+++ b/src/main/java/com/personal_project/coupon/member/applicaion/usecase/AuthMember.java
@@ -3,9 +3,10 @@ package com.personal_project.coupon.member.applicaion.usecase;
 import com.personal_project.coupon.member.domain.Member;
 import com.personal_project.coupon.member.framwork.web.request.MemberInfoDTO;
 import com.personal_project.coupon.member.framwork.web.request.MemberLoginDTO;
+import com.personal_project.coupon.member.framwork.web.response.MemberLoginOutputDTO;
 
 public interface AuthMember {
-    Member login(MemberLoginDTO request);
+    MemberLoginOutputDTO login(MemberLoginDTO request);
 
     Member signUp(MemberInfoDTO request);
 

--- a/src/main/java/com/personal_project/coupon/member/domain/Member.java
+++ b/src/main/java/com/personal_project/coupon/member/domain/Member.java
@@ -15,7 +15,7 @@ import lombok.*;
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
+    @Column(name = "member_id")
     private Long id;
 
     private String email;

--- a/src/main/java/com/personal_project/coupon/member/framwork/web/MemberController.java
+++ b/src/main/java/com/personal_project/coupon/member/framwork/web/MemberController.java
@@ -5,6 +5,7 @@ import com.personal_project.coupon.member.applicaion.usecase.AuthMember;
 import com.personal_project.coupon.member.domain.Member;
 import com.personal_project.coupon.member.framwork.web.request.MemberInfoDTO;
 import com.personal_project.coupon.member.framwork.web.request.MemberLoginDTO;
+import com.personal_project.coupon.member.framwork.web.response.MemberLoginOutputDTO;
 import com.personal_project.coupon.member.framwork.web.response.MemberOutPutDTO;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,9 +28,9 @@ public class MemberController {
     }
 
     @PostMapping("login")
-    public SuccessResponse<MemberOutPutDTO> login(@Valid @RequestBody MemberLoginDTO request){
-        Member member = authMember.login(request);
-        return SuccessResponse.success(MemberOutPutDTO.mapToDTO(member));
+    public SuccessResponse<MemberLoginOutputDTO> login(@Valid @RequestBody MemberLoginDTO request){
+        MemberLoginOutputDTO response = authMember.login(request);
+        return SuccessResponse.success(response);
     }
 
 }

--- a/src/main/java/com/personal_project/coupon/member/framwork/web/response/MemberLoginOutputDTO.java
+++ b/src/main/java/com/personal_project/coupon/member/framwork/web/response/MemberLoginOutputDTO.java
@@ -1,0 +1,21 @@
+package com.personal_project.coupon.member.framwork.web.response;
+
+import com.personal_project.coupon.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberLoginOutputDTO {
+    private Long id;
+    private String email;
+    private String accessToken;
+
+    public static MemberLoginOutputDTO mapToDTO(Member member, String accessToken){
+        return MemberLoginOutputDTO.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/src/test/java/com/personal_project/coupon/service/CouponIssueTest.java
+++ b/src/test/java/com/personal_project/coupon/service/CouponIssueTest.java
@@ -15,24 +15,23 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
 @SpringBootTest
 public class CouponIssueTest {
     @Autowired
-    IssueCoupon issueCoupon;
+    private IssueCoupon issueCoupon;
 
     @Autowired
-    CouponAdapter couponAdapter;
+    private CouponAdapter couponAdapter;
 
 
     @Test
-    void 동시에_100개_요청() throws Exception {
+    void 동시에_1000개_요청() throws Exception {
         final Long eventId = 1L;
         final Long couponId = 1L;
-        final int threadCount = 500;
+        final int threadCount = 1000;
         ExecutorService executorService = Executors.newFixedThreadPool(32);
         CountDownLatch latch = new CountDownLatch(threadCount);
 
@@ -40,7 +39,7 @@ public class CouponIssueTest {
             final Long currentMemberId = i + 1L;
             executorService.submit(() -> {
                 try {
-                    issueCoupon.issue(eventId,couponId,currentMemberId);
+                    issueCoupon.issue(eventId, couponId, currentMemberId);
 
                 } catch (Exception e) {
                     throw new RuntimeException(e);
@@ -51,14 +50,14 @@ public class CouponIssueTest {
         }
         latch.await();
 
-        boolean actualTransactionActive3 = TransactionSynchronizationManager.isActualTransactionActive();
-        System.out.println("끝 actualTransactionActive = " + actualTransactionActive3);
+        boolean actualTransactionActive = TransactionSynchronizationManager.isActualTransactionActive();
+        System.out.println("끝 actualTransactionActive = " + actualTransactionActive);
 
         Optional<Coupon> coupon = couponAdapter.findById(1L);
 
 
         // 500 - 100 == 400
-        assertThat(coupon.get().getIssuedQuantity()).isEqualTo(500);
+        assertThat(coupon.get().getIssuedQuantity()).isEqualTo(1000);
     }
 }
 

--- a/src/test/java/com/personal_project/coupon/service/CouponIssueTest.java
+++ b/src/test/java/com/personal_project/coupon/service/CouponIssueTest.java
@@ -1,0 +1,64 @@
+package com.personal_project.coupon.service;
+
+
+import com.personal_project.coupon.coupon.application.usercase.IssueCoupon;
+import com.personal_project.coupon.coupon.domain.Coupon;
+import com.personal_project.coupon.coupon.framwork.jpaadapter.CouponAdapter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+public class CouponIssueTest {
+    @Autowired
+    IssueCoupon issueCoupon;
+
+    @Autowired
+    CouponAdapter couponAdapter;
+
+
+    @Test
+    void 동시에_100개_요청() throws Exception {
+        final Long eventId = 1L;
+        final Long couponId = 1L;
+        final int threadCount = 500;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final Long currentMemberId = i + 1L;
+            executorService.submit(() -> {
+                try {
+                    issueCoupon.issue(eventId,couponId,currentMemberId);
+
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        boolean actualTransactionActive3 = TransactionSynchronizationManager.isActualTransactionActive();
+        System.out.println("끝 actualTransactionActive = " + actualTransactionActive3);
+
+        Optional<Coupon> coupon = couponAdapter.findById(1L);
+
+
+        // 500 - 100 == 400
+        assertThat(coupon.get().getIssuedQuantity()).isEqualTo(500);
+    }
+}
+


### PR DESCRIPTION
> # 쿠폰 발급 기능 API

  ![image](https://github.com/user-attachments/assets/d08d1fde-93ef-40f4-b2d0-6d31df9c6327)

 - 이벤트 기간 내에 (ex. 2025.03.08 ~ 2025.03.10, 오후 1시~2시 1시간동안 가능) 발급가능 (이벤트 기간 제한, 시간 제한)
 - 선착순 쿠폰의 발행 가능한 최대 수량 설정
 - 선착순 이벤트는 기간 동안 하루에 유저 1명당 1개의 쿠폰만 발급 가능.
>
 - [x] 다양한 락 기법 적용(비관적 락, 네임드락, lettuce 락, redisson락)

---
> # TODO
   1. 락을 통해서 정합성을 맞춰졌지만, 처리량은 낮아서 비동기식으로 처리해야 합니다.
   2. DB를 통해서 자주 사용되는 이벤트와 쿠폰 정보는 캐시 처리를 합니다.

