### PR TITLE
[Feat-13] Order 목록 조회 개선을 위한 역정규화 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
 	implementation 'com.auth0:java-jwt:4.4.0'
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,15 @@
 
 services:
+  mongodb:
+    image: mongo:latest
+    container_name: mongo_order_read
+    ports:
+      - "27017:27017"
+    volumes:
+      - /Users/jeongjuhyeon/개발/docker-mongo/mongo_data:/var/lib/db
+    networks:
+      - coupon-network
+
   # MySQL 서비스
   my-mysql:
     image: mysql:latest
@@ -87,6 +97,25 @@ services:
       - KAFKA_CLUSTERS_0
 
   # Spring Boot 애플리케이션 서비스 (my-server)
+#  my-server:
+#    build: .
+#    container_name: my-server
+#    cpus: 2.0  # CPU 리소스 2개의 vCPU 할당
+#    mem_limit: 2g  # 메모리 2GB로 설정
+#    ports:
+#      - "8080:8080"
+#    depends_on:
+#      - my-mysql
+#      - cache-server
+#    networks:
+#      - coupon-network
+#    privileged: true  # 호스트 자원 접근 허용
+#    healthcheck:
+#      test: [ "CMD", "curl", "-f", "http://localhost:8080/test" ]  # /test 엔드포인트로 건강 체크
+#      interval: 30s
+#      retries: 3
+#      start_period: 10s
+#      timeout: 10s
   my-server:
     build: .
     container_name: my-server
@@ -156,3 +185,18 @@ services:
 networks:
   coupon-network:
     driver: bridge
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/com/personal_project/coupon/global/exception/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/personal_project/coupon/global/exception/errorcode/CommonErrorCode.java
@@ -29,7 +29,6 @@ public enum CommonErrorCode implements ErrorCode{
     USER_PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "4003", "비밀번호가 일치하지 않습니다."),
     LOGOUT_MEMBER(HttpStatus.FORBIDDEN, "3001", "로그아웃된 사용자입니다.(재 로그인 하세요."),
 
-
     //event error(4101 ~ 4200)
     PROMOTION_NOT_FOUND(HttpStatus.NOT_FOUND,"4101","해당 이벤트를 찾을 수 없습니다."),
     PROMOTION_NOT_ACTIVE(HttpStatus.NOT_FOUND,"4102","이벤트 기간이 아닙니다."),
@@ -56,6 +55,10 @@ public enum CommonErrorCode implements ErrorCode{
 
     //menu error(4551 ~ 4600)
     MENU_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"4551","해당 메뉴카테고리는 존재하지 않습니다."),
+
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND,"4601","해당 주문는 존재하지 않습니다."),
+
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND,"4651","해당 결제는 존재하지 않습니다."),
 
     REDIS_SCRIPT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5001", "Redis 스크립트 실행 중 오류가 발생했습니다."),
     LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "5002", "분산 락 획득에 실패했습니다.");

--- a/src/main/java/com/personal_project/coupon/global/util/jwt/JwtUtil.java
+++ b/src/main/java/com/personal_project/coupon/global/util/jwt/JwtUtil.java
@@ -30,7 +30,7 @@ public class JwtUtil {
     private String secretKey;
 
     // 토큰 유효시간 30분
-    public static final long TOKEN_VALID_TIME = 1000L * 60 * 5 ; // 5분(밀리초)
+    public static final long TOKEN_VALID_TIME = 1000L * 60 * 60 ; // 5분(밀리초)
     public static final long REFRESH_TOKEN_VALID_TIME = 1000L * 60 * 60 * 144; // 일주일(밀리초)
     private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
     private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";

--- a/src/main/java/com/personal_project/coupon/order/application/inputport/AddOrderInputPort.java
+++ b/src/main/java/com/personal_project/coupon/order/application/inputport/AddOrderInputPort.java
@@ -1,6 +1,7 @@
 package com.personal_project.coupon.order.application.inputport;
 
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.personal_project.coupon.coupon.application.outputport.CouponIssueOutputPort;
 import com.personal_project.coupon.coupon.domain.model.CouponIssue;
 import com.personal_project.coupon.coupon.domain.model.enumeration.CouponIssueStatus;
@@ -8,10 +9,12 @@ import com.personal_project.coupon.global.exception.BusinessException;
 import com.personal_project.coupon.global.exception.errorcode.CommonErrorCode;
 import com.personal_project.coupon.member.applicaion.outputport.MemberOutputPort;
 import com.personal_project.coupon.member.domain.Member;
+import com.personal_project.coupon.order.application.outputport.OrderEventOutputPort;
 import com.personal_project.coupon.order.application.outputport.OrderOutputPort;
 import com.personal_project.coupon.order.application.usecase.AddOrderUseCase;
 import com.personal_project.coupon.order.domain.model.Order;
 import com.personal_project.coupon.order.domain.model.OrderMenu;
+import com.personal_project.coupon.order.domain.model.event.OrderCreatedEvent;
 import com.personal_project.coupon.order.framwork.web.request.OrderInputDTO;
 import com.personal_project.coupon.order.framwork.web.request.OrderMenuInfoDTO;
 import com.personal_project.coupon.order.framwork.web.response.OrderOutputDTO;
@@ -31,6 +34,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.personal_project.coupon.order.domain.model.Order.createOrderEvent;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -42,10 +47,11 @@ public class AddOrderInputPort implements AddOrderUseCase {
     private final MenuOutputPort menuOutputPort;
     private final OrderOutputPort orderOutputPort;
     private final PaymentOutputPort paymentOutputPort;
+    private final OrderEventOutputPort orderEventOutputPort;
 
     @Override
     @Transactional
-    public OrderOutputDTO create(Long memberId, Long storeId, OrderInputDTO request){
+    public OrderOutputDTO create(Long memberId, Long storeId, OrderInputDTO request) throws JsonProcessingException {
         Member member = memberOutputPort.findById(memberId)
                 .orElseThrow(()-> new BusinessException(CommonErrorCode.USER_NOT_FOUND));
 
@@ -81,6 +87,10 @@ public class AddOrderInputPort implements AddOrderUseCase {
         orderOutputPort.save(order);
 
         paymentOutputPort.save(Payment.create(order,order.getFinalPrice()));
+
+        //이벤트 발행
+        OrderCreatedEvent orderCreatedEvent = createOrderEvent(memberId,order.getId());
+        orderEventOutputPort.occurOrderEvent(orderCreatedEvent);
 
         return OrderOutputDTO.mapToDTO(order.getId());
     }

--- a/src/main/java/com/personal_project/coupon/order/application/inputport/InqueryInputPort.java
+++ b/src/main/java/com/personal_project/coupon/order/application/inputport/InqueryInputPort.java
@@ -1,13 +1,13 @@
 package com.personal_project.coupon.order.application.inputport;
 
-import com.personal_project.coupon.coupon.domain.model.enumeration.DiscountType;
 import com.personal_project.coupon.global.exception.BusinessException;
 import com.personal_project.coupon.global.exception.errorcode.CommonErrorCode;
 import com.personal_project.coupon.order.application.outputport.OrderOutputPort;
+import com.personal_project.coupon.order.application.outputport.OrderSummaryOutputPort;
 import com.personal_project.coupon.order.application.usecase.InquiryOrderUseCase;
 import com.personal_project.coupon.order.domain.model.Order;
+import com.personal_project.coupon.order.domain.model.document.OrderSummaryDocument;
 import com.personal_project.coupon.order.framwork.web.response.OrderInfoOutPutDTO;
-import com.personal_project.coupon.order.framwork.web.response.OrderSummaryOutputDTO;
 import com.personal_project.coupon.payment.application.outputport.PaymentOutputPort;
 import com.personal_project.coupon.payment.domain.model.Payment;
 import com.personal_project.coupon.store.domain.model.Brand;
@@ -18,16 +18,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-
 public class InqueryInputPort implements InquiryOrderUseCase {
 
     private final OrderOutputPort orderOutputPort;
     private final PaymentOutputPort paymentOutputPort;
+    private final OrderSummaryOutputPort orderSummaryOutputPort;
 
     @Override
     public OrderInfoOutPutDTO getOrderDetail(Long memberId, Long orderId){
@@ -48,24 +47,8 @@ public class InqueryInputPort implements InquiryOrderUseCase {
     }
 
     @Override
-    public List<OrderSummaryOutputDTO> getOrder(Long memberId){
-        List<Order> orderList = orderOutputPort.findOrderDetail(memberId);
-
-
-        return orderList.stream()
-                        .map(o-> {
-                            Store store = o.getStore();
-                            StoreCategory storeCategory = store.getStoreCategory();
-                            Brand brand = store.getBrand();
-                            DiscountType discountType = Optional.ofNullable(o.getCouponIssue())
-                                    .map(ci -> ci.getCoupon().getDiscountType())
-                                    .orElse(null); // 또는 기본값 지정
-
-                            return OrderSummaryOutputDTO.mapToDTO(o,storeCategory.getName(),brand.getName(),
-                                    store.getName(), discountType);
-                                }
-                        ).toList();
+    public List<OrderSummaryDocument> getOrder(Long memberId){
+        return orderSummaryOutputPort.findByMemberId(memberId);
     }
-
 
 }

--- a/src/main/java/com/personal_project/coupon/order/application/inputport/InqueryInputPort.java
+++ b/src/main/java/com/personal_project/coupon/order/application/inputport/InqueryInputPort.java
@@ -1,19 +1,16 @@
 package com.personal_project.coupon.order.application.inputport;
 
-import com.personal_project.coupon.coupon.application.outputport.CouponOutputPort;
-import com.personal_project.coupon.coupon.domain.model.Coupon;
+import com.personal_project.coupon.coupon.domain.model.enumeration.DiscountType;
 import com.personal_project.coupon.global.exception.BusinessException;
 import com.personal_project.coupon.global.exception.errorcode.CommonErrorCode;
-import com.personal_project.coupon.member.domain.Member;
 import com.personal_project.coupon.order.application.outputport.OrderOutputPort;
 import com.personal_project.coupon.order.application.usecase.InquiryOrderUseCase;
 import com.personal_project.coupon.order.domain.model.Order;
-import com.personal_project.coupon.order.domain.model.OrderMenu;
 import com.personal_project.coupon.order.framwork.web.response.OrderInfoOutPutDTO;
+import com.personal_project.coupon.order.framwork.web.response.OrderSummaryOutputDTO;
 import com.personal_project.coupon.payment.application.outputport.PaymentOutputPort;
 import com.personal_project.coupon.payment.domain.model.Payment;
 import com.personal_project.coupon.store.domain.model.Brand;
-import com.personal_project.coupon.store.domain.model.Menu;
 import com.personal_project.coupon.store.domain.model.Store;
 import com.personal_project.coupon.store.domain.model.StoreCategory;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -32,7 +30,7 @@ public class InqueryInputPort implements InquiryOrderUseCase {
     private final PaymentOutputPort paymentOutputPort;
 
     @Override
-    public OrderInfoOutPutDTO getOrder(Long memberId, Long orderId){
+    public OrderInfoOutPutDTO getOrderDetail(Long memberId, Long orderId){
 
         Order order = orderOutputPort.findOrderDetail(memberId, orderId)
                .orElseThrow(()-> new BusinessException(CommonErrorCode.ORDER_NOT_FOUND));
@@ -48,5 +46,26 @@ public class InqueryInputPort implements InquiryOrderUseCase {
         return OrderInfoOutPutDTO.mapToDTO(order,storeCategory.getName(),brand.getName(),store.getName(),
                 payment.getAmount());
     }
+
+    @Override
+    public List<OrderSummaryOutputDTO> getOrder(Long memberId){
+        List<Order> orderList = orderOutputPort.findOrderDetail(memberId);
+
+
+        return orderList.stream()
+                        .map(o-> {
+                            Store store = o.getStore();
+                            StoreCategory storeCategory = store.getStoreCategory();
+                            Brand brand = store.getBrand();
+                            DiscountType discountType = Optional.ofNullable(o.getCouponIssue())
+                                    .map(ci -> ci.getCoupon().getDiscountType())
+                                    .orElse(null); // 또는 기본값 지정
+
+                            return OrderSummaryOutputDTO.mapToDTO(o,storeCategory.getName(),brand.getName(),
+                                    store.getName(), discountType);
+                                }
+                        ).toList();
+    }
+
 
 }

--- a/src/main/java/com/personal_project/coupon/order/application/inputport/InqueryInputPort.java
+++ b/src/main/java/com/personal_project/coupon/order/application/inputport/InqueryInputPort.java
@@ -1,0 +1,52 @@
+package com.personal_project.coupon.order.application.inputport;
+
+import com.personal_project.coupon.coupon.application.outputport.CouponOutputPort;
+import com.personal_project.coupon.coupon.domain.model.Coupon;
+import com.personal_project.coupon.global.exception.BusinessException;
+import com.personal_project.coupon.global.exception.errorcode.CommonErrorCode;
+import com.personal_project.coupon.member.domain.Member;
+import com.personal_project.coupon.order.application.outputport.OrderOutputPort;
+import com.personal_project.coupon.order.application.usecase.InquiryOrderUseCase;
+import com.personal_project.coupon.order.domain.model.Order;
+import com.personal_project.coupon.order.domain.model.OrderMenu;
+import com.personal_project.coupon.order.framwork.web.response.OrderInfoOutPutDTO;
+import com.personal_project.coupon.payment.application.outputport.PaymentOutputPort;
+import com.personal_project.coupon.payment.domain.model.Payment;
+import com.personal_project.coupon.store.domain.model.Brand;
+import com.personal_project.coupon.store.domain.model.Menu;
+import com.personal_project.coupon.store.domain.model.Store;
+import com.personal_project.coupon.store.domain.model.StoreCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+
+public class InqueryInputPort implements InquiryOrderUseCase {
+
+    private final OrderOutputPort orderOutputPort;
+    private final PaymentOutputPort paymentOutputPort;
+
+    @Override
+    public OrderInfoOutPutDTO getOrder(Long memberId, Long orderId){
+
+        Order order = orderOutputPort.findOrderDetail(memberId, orderId)
+               .orElseThrow(()-> new BusinessException(CommonErrorCode.ORDER_NOT_FOUND));
+
+//        Member member = order.getMember();
+        Store store = order.getStore();
+        StoreCategory storeCategory = store.getStoreCategory();
+        Brand brand = store.getBrand();
+
+        Payment payment = paymentOutputPort.findByOrderId(orderId)
+                .orElseThrow(()-> new BusinessException(CommonErrorCode.PAYMENT_NOT_FOUND));
+
+        return OrderInfoOutPutDTO.mapToDTO(order,storeCategory.getName(),brand.getName(),store.getName(),
+                payment.getAmount());
+    }
+
+}

--- a/src/main/java/com/personal_project/coupon/order/application/outputport/OrderEventOutputPort.java
+++ b/src/main/java/com/personal_project/coupon/order/application/outputport/OrderEventOutputPort.java
@@ -1,0 +1,9 @@
+package com.personal_project.coupon.order.application.outputport;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.personal_project.coupon.order.domain.model.event.OrderCreatedEvent;
+
+public interface OrderEventOutputPort {
+
+    public void occurOrderEvent(OrderCreatedEvent orderCreatedEvent)throws JsonProcessingException;
+}

--- a/src/main/java/com/personal_project/coupon/order/application/outputport/OrderOutputPort.java
+++ b/src/main/java/com/personal_project/coupon/order/application/outputport/OrderOutputPort.java
@@ -2,7 +2,13 @@ package com.personal_project.coupon.order.application.outputport;
 
 import com.personal_project.coupon.order.domain.model.Order;
 
+import java.util.Optional;
+
 public interface OrderOutputPort {
 
     public Order save(Order order);
+
+    public Optional<Order> findById(Long orderId);
+
+    public Optional<Order> findOrderDetail(Long memberId,Long orderId);
 }

--- a/src/main/java/com/personal_project/coupon/order/application/outputport/OrderOutputPort.java
+++ b/src/main/java/com/personal_project/coupon/order/application/outputport/OrderOutputPort.java
@@ -13,5 +13,7 @@ public interface OrderOutputPort {
 
     public Optional<Order> findOrderDetail(Long memberId,Long orderId);
 
-    public List<Order> findOrderDetail(Long memberId);
+    public List<Order> findOrderList(Long memberId);
+
+    public Optional<Order> findByIdMemberId(Long memberId,Long orderId);
 }

--- a/src/main/java/com/personal_project/coupon/order/application/outputport/OrderOutputPort.java
+++ b/src/main/java/com/personal_project/coupon/order/application/outputport/OrderOutputPort.java
@@ -2,6 +2,7 @@ package com.personal_project.coupon.order.application.outputport;
 
 import com.personal_project.coupon.order.domain.model.Order;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OrderOutputPort {
@@ -11,4 +12,6 @@ public interface OrderOutputPort {
     public Optional<Order> findById(Long orderId);
 
     public Optional<Order> findOrderDetail(Long memberId,Long orderId);
+
+    public List<Order> findOrderDetail(Long memberId);
 }

--- a/src/main/java/com/personal_project/coupon/order/application/outputport/OrderSummaryOutputPort.java
+++ b/src/main/java/com/personal_project/coupon/order/application/outputport/OrderSummaryOutputPort.java
@@ -1,0 +1,14 @@
+package com.personal_project.coupon.order.application.outputport;
+
+import com.personal_project.coupon.order.domain.model.document.OrderSummaryDocument;
+
+import java.util.List;
+
+public interface OrderSummaryOutputPort {
+
+    public OrderSummaryDocument save(OrderSummaryDocument orderSummaryDocument);
+
+    List<OrderSummaryDocument> findByMemberId(Long memberId);
+
+}
+

--- a/src/main/java/com/personal_project/coupon/order/application/usecase/AddOrderUseCase.java
+++ b/src/main/java/com/personal_project/coupon/order/application/usecase/AddOrderUseCase.java
@@ -1,9 +1,10 @@
 package com.personal_project.coupon.order.application.usecase;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.personal_project.coupon.order.framwork.web.request.OrderInputDTO;
 import com.personal_project.coupon.order.framwork.web.response.OrderOutputDTO;
 
 public interface AddOrderUseCase {
 
-    public OrderOutputDTO create(Long memberId, Long storeId, OrderInputDTO request);
+    public OrderOutputDTO create(Long memberId, Long storeId, OrderInputDTO request) throws JsonProcessingException;
 }

--- a/src/main/java/com/personal_project/coupon/order/application/usecase/InquiryOrderUseCase.java
+++ b/src/main/java/com/personal_project/coupon/order/application/usecase/InquiryOrderUseCase.java
@@ -2,8 +2,13 @@ package com.personal_project.coupon.order.application.usecase;
 
 
 import com.personal_project.coupon.order.framwork.web.response.OrderInfoOutPutDTO;
+import com.personal_project.coupon.order.framwork.web.response.OrderSummaryOutputDTO;
+
+import java.util.List;
 
 public interface InquiryOrderUseCase {
 
-    public OrderInfoOutPutDTO getOrder(Long memberId, Long orderId);
+    public OrderInfoOutPutDTO getOrderDetail(Long memberId, Long orderId);
+
+    public List<OrderSummaryOutputDTO> getOrder(Long memberId);
 }

--- a/src/main/java/com/personal_project/coupon/order/application/usecase/InquiryOrderUseCase.java
+++ b/src/main/java/com/personal_project/coupon/order/application/usecase/InquiryOrderUseCase.java
@@ -1,0 +1,9 @@
+package com.personal_project.coupon.order.application.usecase;
+
+
+import com.personal_project.coupon.order.framwork.web.response.OrderInfoOutPutDTO;
+
+public interface InquiryOrderUseCase {
+
+    public OrderInfoOutPutDTO getOrder(Long memberId, Long orderId);
+}

--- a/src/main/java/com/personal_project/coupon/order/application/usecase/InquiryOrderUseCase.java
+++ b/src/main/java/com/personal_project/coupon/order/application/usecase/InquiryOrderUseCase.java
@@ -1,8 +1,8 @@
 package com.personal_project.coupon.order.application.usecase;
 
 
+import com.personal_project.coupon.order.domain.model.document.OrderSummaryDocument;
 import com.personal_project.coupon.order.framwork.web.response.OrderInfoOutPutDTO;
-import com.personal_project.coupon.order.framwork.web.response.OrderSummaryOutputDTO;
 
 import java.util.List;
 
@@ -10,5 +10,5 @@ public interface InquiryOrderUseCase {
 
     public OrderInfoOutPutDTO getOrderDetail(Long memberId, Long orderId);
 
-    public List<OrderSummaryOutputDTO> getOrder(Long memberId);
+    public List<OrderSummaryDocument> getOrder(Long memberId);
 }

--- a/src/main/java/com/personal_project/coupon/order/domain/model/Order.java
+++ b/src/main/java/com/personal_project/coupon/order/domain/model/Order.java
@@ -4,6 +4,7 @@ import com.personal_project.coupon.coupon.domain.model.CouponIssue;
 import com.personal_project.coupon.global.entity.BaseEntity;
 import com.personal_project.coupon.member.domain.Member;
 import com.personal_project.coupon.order.domain.model.enumeration.OrderStatus;
+import com.personal_project.coupon.order.domain.model.event.OrderCreatedEvent;
 import com.personal_project.coupon.store.domain.model.Store;
 import jakarta.persistence.*;
 import lombok.*;
@@ -71,6 +72,10 @@ public class Order extends BaseEntity {
                 LocalDateTime.now(),
                 comment
         );
+    }
+
+    public static OrderCreatedEvent createOrderEvent(Long memberId,Long orderId){
+        return new OrderCreatedEvent(orderId,memberId);
     }
 
     //원가 계산로직

--- a/src/main/java/com/personal_project/coupon/order/domain/model/Order.java
+++ b/src/main/java/com/personal_project/coupon/order/domain/model/Order.java
@@ -50,8 +50,8 @@ public class Order extends BaseEntity {
 
     private String comment;
 
+    @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
-
     private Order(Member member, Store store, CouponIssue couponIssue, String deliveryAddress, LocalDateTime orderTime, String comment){
         this.member = member;
         this.store = store;
@@ -93,12 +93,12 @@ public class Order extends BaseEntity {
         this.orderMenuList.add(orderMenu);
         orderMenu.changeOrder(this); // setter 대신 연관관계 메서드 호출
     }
+
     // 연관관계 편의 메서드 (컬렉션)
     public void addOrderMenus(List<OrderMenu> orderMenus) {
         for (OrderMenu orderMenu : orderMenus) {
             addOrderMenu(orderMenu); // 단건 추가 재사용
         }
     }
-
 
 }

--- a/src/main/java/com/personal_project/coupon/order/domain/model/document/OrderSummaryDocument.java
+++ b/src/main/java/com/personal_project/coupon/order/domain/model/document/OrderSummaryDocument.java
@@ -1,0 +1,90 @@
+package com.personal_project.coupon.order.domain.model.document;
+
+import com.personal_project.coupon.coupon.domain.model.enumeration.DiscountType;
+import com.personal_project.coupon.order.domain.model.Order;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(collection = "orders_summaries") // MongoDB 컬렉션 이름
+@CompoundIndex(def = "{'memberId': 1, 'orderTime': -1}")
+public class OrderSummaryDocument {
+
+    @Id
+    private String id;
+
+    private Long memberId;
+    private Long orderId;
+    private Integer originalPrice;
+    private Integer discountAmount;
+    private Integer finalPrice;
+    private LocalDateTime orderTime;
+    private String orderStatus;
+
+    private String storeCategoryName;
+    private String storeBrandName;
+    private String storeName;
+
+    private List<OrderMenuDocument> orderMenuList;
+
+    private DiscountType discountType;
+
+    @Getter
+    @Builder
+    public static class OrderMenuDocument {
+        private Long orderMenuId;
+        private Long menuId;
+        private String name;
+        private Integer price;
+        private Integer quantity;
+        private Integer totalPrice;
+
+        public static OrderMenuDocument mapToDTO(Long orderMenuId, Long menuId,
+                                                 String name, Integer price,
+                                                 Integer quantity, Integer totalPrice){
+            return OrderMenuDocument.builder()
+                    .orderMenuId(orderMenuId)
+                    .menuId(menuId)
+                    .name(name)
+                    .price(price)
+                    .quantity(quantity)
+                    .totalPrice(totalPrice)
+                    .build();
+        }
+    }
+
+    // DTO → Document 변환 메서드
+    public static OrderSummaryDocument fromEvent(Order order,Long memberId, String storeCategoryName,
+                                               String storeBrandName, String storeName,
+                                               DiscountType discountType) {
+        return OrderSummaryDocument.builder()
+                .orderId(order.getId())
+                .memberId(memberId)
+                .originalPrice(order.getOriginalPrice())
+                .discountAmount(order.getDiscountAmount())
+                .finalPrice(order.getFinalPrice())
+                .orderTime(order.getOrderTime())
+                .orderStatus(order.getOrderStatus().name())
+                .storeCategoryName(storeCategoryName)
+                .storeBrandName(storeBrandName)
+                .storeName(storeName)
+                .orderMenuList(order.getOrderMenuList().stream()
+                        .map(o-> OrderMenuDocument.mapToDTO(o.getId(),o.getMenu().getId(),
+                                o.getMenu().getName(),o.getPrice(),o.getQuantity(),o.getTotalPrice())).collect(Collectors.toList()))
+                .discountType(discountType)
+                .build();
+    }
+
+}

--- a/src/main/java/com/personal_project/coupon/order/domain/model/event/OrderCreatedEvent.java
+++ b/src/main/java/com/personal_project/coupon/order/domain/model/event/OrderCreatedEvent.java
@@ -1,0 +1,13 @@
+package com.personal_project.coupon.order.domain.model.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderCreatedEvent {
+    private Long orderId;
+    private Long memberId;
+}

--- a/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderAdapter.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderAdapter.java
@@ -5,6 +5,7 @@ import com.personal_project.coupon.order.domain.model.Order;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -27,5 +28,11 @@ public class OrderAdapter implements OrderOutputPort {
     public Optional<Order> findOrderDetail(Long memberId,Long orderId){
         return orderJpaRepository.findOrderDetail(memberId,orderId);
     }
+
+    @Override
+    public List<Order> findOrderDetail(Long memberId){
+        return orderJpaRepository.findOrderList(memberId);
+    }
+
 
 }

--- a/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderAdapter.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderAdapter.java
@@ -5,6 +5,8 @@ import com.personal_project.coupon.order.domain.model.Order;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class OrderAdapter implements OrderOutputPort {
@@ -13,6 +15,17 @@ public class OrderAdapter implements OrderOutputPort {
     @Override
     public Order save(Order order){
         return orderJpaRepository.save(order);
+    }
+
+    @Override
+    public Optional<Order> findById(Long orderId){
+        return orderJpaRepository.findById(orderId);
+    }
+
+
+    @Override
+    public Optional<Order> findOrderDetail(Long memberId,Long orderId){
+        return orderJpaRepository.findOrderDetail(memberId,orderId);
     }
 
 }

--- a/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderAdapter.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderAdapter.java
@@ -30,8 +30,13 @@ public class OrderAdapter implements OrderOutputPort {
     }
 
     @Override
-    public List<Order> findOrderDetail(Long memberId){
+    public List<Order> findOrderList(Long memberId){
         return orderJpaRepository.findOrderList(memberId);
+    }
+
+    @Override
+    public Optional<Order> findByIdMemberId(Long orderId,Long memberId){
+        return orderJpaRepository.findOrder(memberId,orderId);
     }
 
 

--- a/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderJpaRepository.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderJpaRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OrderJpaRepository extends JpaRepository<Order, Long> {
@@ -15,8 +16,23 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
             join fetch o.store s
             join fetch s.storeCategory
             join fetch s.brand
-            where o.id = :orderId and o.member.id = :memberId""")
+            where o.id = :orderId and o.member.id = :memberId
+            """)
     public Optional<Order> findOrderDetail(@Param("memberId") Long memberId,
                                            @Param("orderId") Long orderId);
 
+
+
+    @Query("""
+            select o from Order o
+            join fetch o.store s
+            join fetch s.storeCategory
+            join fetch s.brand
+            left join o.couponIssue ci
+            left join ci.coupon c
+            where o.member.id = :memberId
+            ORDER BY o.createdAt DESC
+            LIMIT 20
+            """)
+    public List<Order> findOrderList(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderJpaRepository.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderJpaRepository.java
@@ -2,6 +2,21 @@ package com.personal_project.coupon.order.framwork.jpaadpter;
 
 import com.personal_project.coupon.order.domain.model.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface OrderJpaRepository extends JpaRepository<Order, Long> {
+
+
+    @Query(""" 
+            select o from Order o
+            join fetch o.store s
+            join fetch s.storeCategory
+            join fetch s.brand
+            where o.id = :orderId and o.member.id = :memberId""")
+    public Optional<Order> findOrderDetail(@Param("memberId") Long memberId,
+                                           @Param("orderId") Long orderId);
+
 }

--- a/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderJpaRepository.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderJpaRepository.java
@@ -21,8 +21,6 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
     public Optional<Order> findOrderDetail(@Param("memberId") Long memberId,
                                            @Param("orderId") Long orderId);
 
-
-
     @Query("""
             select o from Order o
             join fetch o.store s
@@ -35,4 +33,16 @@ public interface OrderJpaRepository extends JpaRepository<Order, Long> {
             LIMIT 20
             """)
     public List<Order> findOrderList(@Param("memberId") Long memberId);
+
+    @Query(""" 
+            select o from Order o
+            join fetch o.store s
+            join fetch s.storeCategory
+            join fetch s.brand
+            left join o.couponIssue ci
+            left join ci.coupon c
+            where o.id = :orderId and o.member.id = :memberId
+            """)
+    public Optional<Order> findOrder(@Param("memberId") Long memberId,
+                                     @Param("orderId") Long orderId);
 }

--- a/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderSummaryAdapter.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderSummaryAdapter.java
@@ -1,0 +1,23 @@
+package com.personal_project.coupon.order.framwork.jpaadpter;
+
+import com.personal_project.coupon.order.application.outputport.OrderSummaryOutputPort;
+import com.personal_project.coupon.order.domain.model.document.OrderSummaryDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderSummaryAdapter implements OrderSummaryOutputPort {
+    private final OrderSummaryJpaRepository orderSummaryJpaRepository;
+
+    @Override
+    public OrderSummaryDocument save(OrderSummaryDocument orderSummaryDocument){
+        return orderSummaryJpaRepository.save(orderSummaryDocument);
+    }
+    @Override
+    public List<OrderSummaryDocument> findByMemberId(Long memberId){
+        return orderSummaryJpaRepository.findTop20ByMemberIdOrderByOrderTimeDesc(memberId);
+    }
+}

--- a/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderSummaryJpaRepository.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/jpaadpter/OrderSummaryJpaRepository.java
@@ -1,0 +1,12 @@
+package com.personal_project.coupon.order.framwork.jpaadpter;
+
+import com.personal_project.coupon.order.domain.model.document.OrderSummaryDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface OrderSummaryJpaRepository extends MongoRepository<OrderSummaryDocument,Long> {
+
+    List<OrderSummaryDocument> findTop20ByMemberIdOrderByOrderTimeDesc(Long memberId);
+
+}

--- a/src/main/java/com/personal_project/coupon/order/framwork/kafkaadapter/OrderCreatedConsumer.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/kafkaadapter/OrderCreatedConsumer.java
@@ -1,0 +1,62 @@
+package com.personal_project.coupon.order.framwork.kafkaadapter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal_project.coupon.coupon.domain.model.enumeration.DiscountType;
+import com.personal_project.coupon.global.exception.BusinessException;
+import com.personal_project.coupon.global.exception.errorcode.CommonErrorCode;
+import com.personal_project.coupon.order.application.outputport.OrderOutputPort;
+import com.personal_project.coupon.order.application.outputport.OrderSummaryOutputPort;
+import com.personal_project.coupon.order.domain.model.Order;
+import com.personal_project.coupon.order.domain.model.document.OrderSummaryDocument;
+import com.personal_project.coupon.order.domain.model.event.OrderCreatedEvent;
+import com.personal_project.coupon.store.domain.model.Brand;
+import com.personal_project.coupon.store.domain.model.Store;
+import com.personal_project.coupon.store.domain.model.StoreCategory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class OrderCreatedConsumer {
+
+    private final OrderOutputPort orderOutputPort;
+    private final OrderSummaryOutputPort orderSummaryOutputPort;
+    private final ObjectMapper objectMapper;
+
+
+    @KafkaListener(topics = "${kafka.consumer.topic3.name}", groupId = "${kafka.consumer.topic3.groupid}")
+    public void consumeOrderCreated(ConsumerRecord<String, String> record) throws IOException {
+        System.out.println("issue:" + record.value());
+
+        OrderCreatedEvent orderCreatedEvent = objectMapper.readValue(record.value(),OrderCreatedEvent.class);
+
+
+        Order order = orderOutputPort.findByIdMemberId(orderCreatedEvent.getOrderId(),orderCreatedEvent.getMemberId())
+                .orElseThrow(()-> new BusinessException(CommonErrorCode.ORDER_NOT_FOUND));
+
+        Store store = order.getStore();
+        StoreCategory storeCategory = store.getStoreCategory();
+        Brand brand = store.getBrand();
+
+        DiscountType discountType = Optional.ofNullable(order.getCouponIssue())
+                .map(ci -> ci.getCoupon().getDiscountType())
+                .orElse(null); // 또는 기본값 지정
+
+        OrderSummaryDocument orderSummaryDocument =
+                OrderSummaryDocument.fromEvent(order,orderCreatedEvent.getMemberId(),
+                        storeCategory.getName(),
+                        brand.getName(),store.getName(), discountType);
+
+        orderSummaryOutputPort.save(orderSummaryDocument);
+
+    }
+}

--- a/src/main/java/com/personal_project/coupon/order/framwork/kafkaadapter/OrderCreatedProducer.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/kafkaadapter/OrderCreatedProducer.java
@@ -1,0 +1,40 @@
+package com.personal_project.coupon.order.framwork.kafkaadapter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.personal_project.coupon.order.application.outputport.OrderEventOutputPort;
+import com.personal_project.coupon.order.domain.model.event.OrderCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderCreatedProducer implements OrderEventOutputPort {
+    @Value(value = "${kafka.producers.topic3.name}")
+    private String TOPIC;
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Override
+    public void occurOrderEvent(OrderCreatedEvent result)throws JsonProcessingException {
+
+        CompletableFuture<SendResult<String, Object>> future = kafkaTemplate.send(TOPIC, result);
+
+        future.thenAccept(sendResult -> {
+            OrderCreatedEvent sentResult = (OrderCreatedEvent) sendResult.getProducerRecord().value();
+            log.info("Sent message=[{}] with offset=[{}]",
+                    sentResult.getOrderId(), sendResult.getRecordMetadata().offset());
+        }).exceptionally(ex -> {
+            log.error("Unable to send message=[{}] due to: {}",
+                    result.getOrderId(), ex.getMessage(), ex);
+            return null;
+        });
+    }
+
+}

--- a/src/main/java/com/personal_project/coupon/order/framwork/web/OrderController.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/web/OrderController.java
@@ -1,13 +1,14 @@
 package com.personal_project.coupon.order.framwork.web;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.personal_project.coupon.global.exception.response.SuccessResponse;
 import com.personal_project.coupon.global.util.jwt.CustomUserDetails;
 import com.personal_project.coupon.order.application.usecase.AddOrderUseCase;
 import com.personal_project.coupon.order.application.usecase.InquiryOrderUseCase;
+import com.personal_project.coupon.order.domain.model.document.OrderSummaryDocument;
 import com.personal_project.coupon.order.framwork.web.request.OrderInputDTO;
 import com.personal_project.coupon.order.framwork.web.response.OrderInfoOutPutDTO;
 import com.personal_project.coupon.order.framwork.web.response.OrderOutputDTO;
-import com.personal_project.coupon.order.framwork.web.response.OrderSummaryOutputDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +26,7 @@ public class OrderController {
     @PostMapping("/create/{storeId}")
     public SuccessResponse<OrderOutputDTO> create(@AuthenticationPrincipal CustomUserDetails member,
                                                   @PathVariable Long storeId,
-                                                  @RequestBody OrderInputDTO request){
+                                                  @RequestBody OrderInputDTO request) throws JsonProcessingException {
         Long memberId = member.getMemberId();
         OrderOutputDTO response =addOrderUseCase.create(memberId, storeId, request);
 
@@ -42,10 +43,10 @@ public class OrderController {
     }
 
     @GetMapping("")
-    public SuccessResponse<List<OrderSummaryOutputDTO>> getOrder(@AuthenticationPrincipal CustomUserDetails member){
+    public SuccessResponse<List<OrderSummaryDocument>> getOrder(@AuthenticationPrincipal CustomUserDetails member){
 
         Long memberId = member.getMemberId();
-        List<OrderSummaryOutputDTO> response = inquiryOrderUseCase.getOrder(memberId);
+        List<OrderSummaryDocument> response = inquiryOrderUseCase.getOrder(memberId);
 
         return SuccessResponse.success(response);
     }

--- a/src/main/java/com/personal_project/coupon/order/framwork/web/OrderController.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/web/OrderController.java
@@ -3,7 +3,9 @@ package com.personal_project.coupon.order.framwork.web;
 import com.personal_project.coupon.global.exception.response.SuccessResponse;
 import com.personal_project.coupon.global.util.jwt.CustomUserDetails;
 import com.personal_project.coupon.order.application.usecase.AddOrderUseCase;
+import com.personal_project.coupon.order.application.usecase.InquiryOrderUseCase;
 import com.personal_project.coupon.order.framwork.web.request.OrderInputDTO;
+import com.personal_project.coupon.order.framwork.web.response.OrderInfoOutPutDTO;
 import com.personal_project.coupon.order.framwork.web.response.OrderOutputDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class OrderController {
 
     private final AddOrderUseCase addOrderUseCase;
-
+    private final InquiryOrderUseCase inquiryOrderUseCase;
 
     @PostMapping("/create/{storeId}")
     public SuccessResponse<OrderOutputDTO> create(@AuthenticationPrincipal CustomUserDetails member,
@@ -25,6 +27,17 @@ public class OrderController {
         OrderOutputDTO response =addOrderUseCase.create(memberId, storeId, request);
 
         return SuccessResponse.success(response);
+    }
+
+    @GetMapping("/{orderId}")
+    public SuccessResponse<OrderInfoOutPutDTO> getOrder(@AuthenticationPrincipal CustomUserDetails member,
+                                                        @PathVariable Long orderId){
+        Long memberId = member.getMemberId();
+
+        OrderInfoOutPutDTO response = inquiryOrderUseCase.getOrder(memberId,orderId);
+
+        return SuccessResponse.success(response);
+
     }
 
 }

--- a/src/main/java/com/personal_project/coupon/order/framwork/web/OrderController.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/web/OrderController.java
@@ -7,9 +7,12 @@ import com.personal_project.coupon.order.application.usecase.InquiryOrderUseCase
 import com.personal_project.coupon.order.framwork.web.request.OrderInputDTO;
 import com.personal_project.coupon.order.framwork.web.response.OrderInfoOutPutDTO;
 import com.personal_project.coupon.order.framwork.web.response.OrderOutputDTO;
+import com.personal_project.coupon.order.framwork.web.response.OrderSummaryOutputDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,14 +33,21 @@ public class OrderController {
     }
 
     @GetMapping("/{orderId}")
-    public SuccessResponse<OrderInfoOutPutDTO> getOrder(@AuthenticationPrincipal CustomUserDetails member,
+    public SuccessResponse<OrderInfoOutPutDTO> getOrderDetail(@AuthenticationPrincipal CustomUserDetails member,
                                                         @PathVariable Long orderId){
         Long memberId = member.getMemberId();
-
-        OrderInfoOutPutDTO response = inquiryOrderUseCase.getOrder(memberId,orderId);
+        OrderInfoOutPutDTO response = inquiryOrderUseCase.getOrderDetail(memberId,orderId);
 
         return SuccessResponse.success(response);
+    }
 
+    @GetMapping("")
+    public SuccessResponse<List<OrderSummaryOutputDTO>> getOrder(@AuthenticationPrincipal CustomUserDetails member){
+
+        Long memberId = member.getMemberId();
+        List<OrderSummaryOutputDTO> response = inquiryOrderUseCase.getOrder(memberId);
+
+        return SuccessResponse.success(response);
     }
 
 }

--- a/src/main/java/com/personal_project/coupon/order/framwork/web/response/OrderInfoOutPutDTO.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/web/response/OrderInfoOutPutDTO.java
@@ -1,0 +1,52 @@
+package com.personal_project.coupon.order.framwork.web.response;
+
+import com.personal_project.coupon.order.domain.model.Order;
+import com.personal_project.coupon.order.domain.model.enumeration.OrderStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class OrderInfoOutPutDTO {
+    private Long orderId;
+    private Integer originalPrice;
+    private Integer discountAmount;
+    private Integer finalPrice;
+    private String deliveryAddress;
+    private LocalDateTime orderTime;
+    private String comment;
+    private OrderStatus orderStatus;
+
+    private String storeCategoryName;
+    private String storeBrandName;
+    private String storeName;
+
+    private List<OrderMenuOutputDTO> orderMenuOutputDTOList;
+
+    private Integer amount;
+
+    public static OrderInfoOutPutDTO mapToDTO(Order order,String storeCategoryName,String storeBrandName,
+                                              String storeName,Integer amount){
+        return OrderInfoOutPutDTO.builder()
+                .orderId(order.getId())
+                .originalPrice(order.getOriginalPrice())
+                .discountAmount(order.getDiscountAmount())
+                .finalPrice(order.getFinalPrice())
+                .deliveryAddress(order.getDeliveryAddress())
+                .orderTime(order.getOrderTime())
+                .comment(order.getComment())
+                .orderStatus(order.getOrderStatus())
+                .storeCategoryName(storeCategoryName)
+                .storeBrandName(storeBrandName)
+                .storeName(storeName)
+                .orderMenuOutputDTOList(order.getOrderMenuList().stream()
+                        .map(o-> OrderMenuOutputDTO.mapToDTO(o.getId(),o.getMenu().getId(),
+                                o.getMenu().getName(),o.getPrice(),o.getQuantity(),o.getTotalPrice())).collect(Collectors.toList()))
+                .amount(amount)
+                .build();
+    }
+}

--- a/src/main/java/com/personal_project/coupon/order/framwork/web/response/OrderMenuOutputDTO.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/web/response/OrderMenuOutputDTO.java
@@ -1,0 +1,30 @@
+package com.personal_project.coupon.order.framwork.web.response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderMenuOutputDTO {
+    private Long orderMenuId;
+    private Long menuId;
+    private String name;
+    private Integer price;
+    private Integer quantity;
+    private Integer totalPrice;
+
+
+    public static OrderMenuOutputDTO mapToDTO(Long orderMenuId, Long menuId,
+                                              String name, Integer price,
+                                              Integer quantity, Integer totalPrice){
+        return OrderMenuOutputDTO.builder()
+                .orderMenuId(orderMenuId)
+                .menuId(menuId)
+                .name(name)
+                .price(price)
+                .quantity(quantity)
+                .totalPrice(totalPrice)
+                .build();
+    }
+}

--- a/src/main/java/com/personal_project/coupon/order/framwork/web/response/OrderSummaryOutputDTO.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/web/response/OrderSummaryOutputDTO.java
@@ -1,0 +1,51 @@
+package com.personal_project.coupon.order.framwork.web.response;
+
+import com.personal_project.coupon.coupon.domain.model.enumeration.DiscountType;
+import com.personal_project.coupon.order.domain.model.Order;
+import com.personal_project.coupon.order.domain.model.enumeration.OrderStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+public class OrderSummaryOutputDTO {
+
+    private Long orderId;
+    private Integer originalPrice;
+    private Integer discountAmount;
+    private Integer finalPrice;
+    private LocalDateTime orderTime;
+    private OrderStatus orderStatus;
+
+    private String storeCategoryName;
+    private String storeBrandName;
+    private String storeName;
+
+    private List<OrderMenuOutputDTO> orderMenuOutputDTOList;
+
+    private DiscountType discountType;
+
+    public static OrderSummaryOutputDTO mapToDTO(Order order,String storeCategoryName,
+                                                 String storeBrandName, String storeName,
+                                                 DiscountType discountType){
+        return OrderSummaryOutputDTO.builder()
+                .orderId(order.getId())
+                .originalPrice(order.getOriginalPrice())
+                .discountAmount(order.getDiscountAmount())
+                .finalPrice(order.getFinalPrice())
+                .orderTime(order.getOrderTime())
+                .orderStatus(order.getOrderStatus())
+                .storeCategoryName(storeCategoryName)
+                .storeBrandName(storeBrandName)
+                .storeName(storeName)
+                .orderMenuOutputDTOList(order.getOrderMenuList().stream()
+                .map(o-> OrderMenuOutputDTO.mapToDTO(o.getId(),o.getMenu().getId(),
+                        o.getMenu().getName(),o.getPrice(),o.getQuantity(),o.getTotalPrice())).collect(Collectors.toList()))
+                .discountType(discountType)
+                .build();
+    }
+}

--- a/src/main/java/com/personal_project/coupon/payment/application/outputport/PaymentOutputPort.java
+++ b/src/main/java/com/personal_project/coupon/payment/application/outputport/PaymentOutputPort.java
@@ -2,7 +2,11 @@ package com.personal_project.coupon.payment.application.outputport;
 
 import com.personal_project.coupon.payment.domain.model.Payment;
 
+import java.util.Optional;
+
 public interface PaymentOutputPort {
 
     public void save(Payment payment);
+    public Optional<Payment> findByOrderId(Long paymentId);
 }
+

--- a/src/main/java/com/personal_project/coupon/payment/framwork/jpaadpter/PaymentAdapter.java
+++ b/src/main/java/com/personal_project/coupon/payment/framwork/jpaadpter/PaymentAdapter.java
@@ -5,6 +5,8 @@ import com.personal_project.coupon.payment.domain.model.Payment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class PaymentAdapter implements PaymentOutputPort {
@@ -15,4 +17,10 @@ public class PaymentAdapter implements PaymentOutputPort {
     public void save(Payment payment){
         paymentJpaRepository.save(payment);
     }
+
+    @Override
+    public Optional<Payment> findByOrderId(Long paymentId){
+       return paymentJpaRepository.findByOrderId(paymentId);
+    }
+
 }

--- a/src/main/java/com/personal_project/coupon/payment/framwork/jpaadpter/PaymentJpaRepository.java
+++ b/src/main/java/com/personal_project/coupon/payment/framwork/jpaadpter/PaymentJpaRepository.java
@@ -3,5 +3,9 @@ package com.personal_project.coupon.payment.framwork.jpaadpter;
 import com.personal_project.coupon.payment.domain.model.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PaymentJpaRepository extends JpaRepository<Payment,Long> {
+
+    Optional<Payment> findByOrderId(Long orderId);
 }

--- a/src/main/java/com/personal_project/coupon/store/domain/model/Store.java
+++ b/src/main/java/com/personal_project/coupon/store/domain/model/Store.java
@@ -22,7 +22,7 @@ public class Store extends BaseEntity {
     @Column(name = "store_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "brand_id")
     private Brand brand;
 


### PR DESCRIPTION
> ## 🧩 Order 목록 조회 개선을 위한 역정규화 적용

기존 "나의 주문 목록 조회" 로직은 Root엔티티를  Order 기준으로 하여 연관된 Entity를 Fetch조인을 통해서 
가져왔으며, Coupon, CouponIssue는 Null일 가능성이 있으므로, Left Join을 통해서 연관된 엔티티를 조회하였습니다.

<img width="541" height="269" alt="image" src="https://github.com/user-attachments/assets/bfe3131f-cfb1-40c0-bb5f-9b91eb131ef9" />

위와 같은 쿼리로 주문목록을 조회하였습니다.
페이징 처리는 하지않았으며, 단순 Limit를 통하여 최근 주문한 내역을 createAt를 통하여 조회하도록 구현했습니다.
또한, orderMenuList와 같은 1:N 관계의 데이터는 N+1문제가 발생하지 않도록, default_batch_fetch_size: 200를 통하여  in을 통해서 조회하도록 구성했습니다.

 ### ✔️ **쿼리 실행 결과**

    -> Limit: 20 row(s)  (cost=427 rows=20) (actual time=1.53..1.56 rows=20 loops=1)
    -> Nested loop inner join  (cost=427 rows=90) (actual time=1.52..1.55 rows=20 loops=1)
        -> Nested loop inner join  (cost=396 rows=90) (actual time=1.5..1.52 rows=20 loops=1)
            -> Nested loop inner join  (cost=297 rows=90) (actual time=1.39..1.41 rows=20 loops=1)
                -> Nested loop left join  (cost=198 rows=90) (actual time=1.2..1.21 rows=20 loops=1)
                    -> Sort: o1_0.created_at DESC  (cost=99 rows=90) (actual time=1.18..1.18 rows=20 loops=1)
                        -> Filter: (o1_0.store_id is not null)  (cost=99 rows=90) (actual time=0.594..0.965 rows=90 loops=1)
                            -> Index lookup on o1_0 using FKpktxwhj3x9m4gth5ff6bkqgeb (member_id = 5000001)  (cost=99 rows=90) (actual time=0.579..0.942 rows=90 loops=1)
                    -> Single-row covering index lookup on ci1_0 using PRIMARY (coupon_issue_id = o1_0.coupon_issue_id)  (cost=1 rows=1) (actual time=0.0011..0.0011 rows=0 loops=20)
                -> Filter: ((s1_0.brand_id is not null) and (s1_0.store_category_id is not null))  (cost=1 rows=1) (actual time=0.00973..0.00981 rows=1 loops=20)
                    -> Single-row index lookup on s1_0 using PRIMARY (store_id = o1_0.store_id)  (cost=1 rows=1) (actual time=0.00952..0.00954 rows=1 loops=20)
            -> Single-row index lookup on b1_0 using PRIMARY (brand_id = s1_0.brand_id)  (cost=1 rows=1) (actual time=0.00556..0.00558 rows=1 loops=20)
        -> Single-row index lookup on sc1_0 using PRIMARY (store_category_id = s1_0.store_category_id)  (cost=0.251 rows=1) (actual time=0.00117..0.0012 rows=1 loops=20)


<img width="507" height="750" alt="스크린샷 2025-11-12 오후 8 10 33" src="https://github.com/user-attachments/assets/35eae53f-6641-44b8-aa18-66a3bbf52a22" />


현재 시스템에서는 memberId 기반으로 Order 데이터를 조회하는데, Order 테이블의 memberId는 인덱스가 잡혀 있어 데이터가 100만 건 이상 존재하더라도 해당 사용자에 대한 Order만 효율적으로 조회할 수 있어 성능 저하가 크지 않습니다. 실제 EXPLAIN ANALYZE 결과에서도 대부분의 연관 엔티티가 단일 행 인덱스 조회와 Nested Loop Join으로 빠르게 매칭되며, 전체 조회 시간 역시 약 75ms 수준으로 충분히 빠르게 측정되었습니다.

> ## 🧩 MSA 전환 이후 발생한 성능 저하
문제는 시스템을 MSA 구조로 전환한 이후 발생했습니다.
MSA 전환 후에는 더 이상 SQL JOIN이 불가능해졌습니다.

대신, 주문 조회 로직은 아래와 같이 변경되었습니다.

     1. Order-Service에서 주문 목록 조회
     2. Store-Service 호출 → 가게/브랜드/카테고리 정보 조회
     3. Payment-Service 호출 → 결제 정보 조회
     4. Coupon-Service 호출 → 쿠폰 정보 조회
     5. 각 서비스의 응답을 JVM 레벨에서 조립

즉, 기존의 DB JOIN이 서비스 간 분산 호출 + 애플리케이션 레벨 조립으로 대체되었습니다.

 ### ✔️ **실행 결과**

<img width="836" height="764" alt="image" src="https://github.com/user-attachments/assets/3f48513c-f538-46d7-96fe-f19d79d04edd" />

MSA 전환 후 조회 시간이 약 1.88초까지 증가한 원인은

     여러 서비스(Store, Payment, Coupon 등)를 호출
     JVM 메모리 상에서 데이터 조립 비용 발생

DB 내부에서 처리되던 JOIN 연산이 분산 환경에서의 논리적 JOIN으로 바뀌면서 성능 병목이 발생한 것입니다.

 ### 📌 **한계 인식**

이 시점에서 다음과 같은 결론에 도달했습니다.

     - 쿼리 튜닝으로 해결할 수 있는 문제의 범위를 벗어남
     - Fetch Join / Index 최적화로는 분산 호출 비용을 줄일 수 없음
     - 주문 조회는 쓰기보다 읽기 비중이 높고
     - 조회 시점마다 여러 서비스를 호출해 데이터를 조립하는 구조는 트래픽 증가에 매우 취약

이러한 구조적 한계를 해결하기 위해 CQRS + 역정규화된 조회 전용 모델 도입을 검토하게 되었습니다.

<img width="749" height="334" alt="Image" src="https://github.com/user-attachments/assets/ba1886ec-da8d-4360-ac0a-9db5b294f8a5" />

위와 같이 주문 저장 API와 주문 조회 API를 분리하여, 주문 저장은 RDB에 수행하고, 조회는 NoSQL인 MongoDB를 통해 수행하도록 설계하였습니다. 조회 시에는 memberId를 기준으로 역정규화된 문서(Document)를 가져오기 때문에, 조인 연산 없이도 단순 조회만으로 매우 빠르게 결과를 반환할 수 있습니다.

MongoDB의 Document 구조는 다음과 같이 설계하였습니다.
 필드이름 | 데이터 타입 | 설명 | 
|------|------|------|
| Id |  Int64 | 기본키, 각 레코드의 고유 식별자 |
| memberId | Int64 | 사용자 식별자 |
| orderId | Int64 | 주문 식별자 |
| originalPrice | Int32 | 원가 |
| discountAmount |  Int32 | 할인 금액 |
| finalPrice |  Int32 | 최종금액 |
| orderTime |  TIMESTAMP | 주문시간 |
| orderStatus | String | 주문상태 (PENDING,ACCEPTED,IN_PROGRESS,READY,COMPLETED,CANCELLED,FAILED,REFUNDED |
| storeCategoryName | (String | 가게 카테고리 명 |
| storeBrandName |  String | 가게 브랜드 명 |
| storeName | String | 가게명 |
| orderMenuList |  List | 주문 메뉴 리스트 |

<img width="713" height="208" alt="image" src="https://github.com/user-attachments/assets/813e9138-6746-4f27-b9e3-0e0a87e48f3a" />

주문 발생 시, 주문 정보를 MySQL(RDB)에 저장한 후 OrderCreatedEvent를 생성하여 Kafka 토픽으로 발행합니다.

OrderCreatedEvent 구조는 아래와 같으며, 이벤트에 모든 정보를 담으면 해당 토픽을 구독하는 다른 컨슈머에서 불필요한 데이터를 받게 되므로, 조회용 최소한의 정보(orderId, memberId)만 포함하도록 설계했습니다.

<img width="269" height="157" alt="image" src="https://github.com/user-attachments/assets/73f15ff9-27d5-42dc-9df1-31e9a8f19e54" />

<img width="606" height="600" alt="image" src="https://github.com/user-attachments/assets/84eaac64-5e0b-4718-a33b-c8e5afe95226" />

컨슈머는 내부 통신을 통해 RDB에서 필요한 데이터를 가져와 MongoDB에 저장하는 형태로 변경하게 됩니다.

<br><br>
### ✅ 주문 조회 로직

주문은 memberId를 기준으로 조회하며, createAt 기준으로 내림차순 정렬되어 매우 빠르게 조회할 수 있도록 설계되었습니다.

<img width="502" height="123" alt="image" src="https://github.com/user-attachments/assets/b7e1e964-c49c-4012-b70b-bdb54d30cbff" />

<img width="711" height="97" alt="image" src="https://github.com/user-attachments/assets/c0d81799-c516-4f00-b469-b823dbe594c4" />

<img width="629" height="758" alt="image" src="https://github.com/user-attachments/assets/75194ad2-3442-4f1e-901e-7e6dacb3491b" />

이처럼 역정규화된 데이터 구조를 활용하여, 단순히 memberId만으로도 빠른 조회가 가능하며 안정적인 성능을 보장합니다.

<br><br>

> ## 🧩 결과
**MSA 전환 직후**
- 주문 조회 시 여러 서비스(Store, Payment, Coupon 등)를 동기 호출하여 JVM에서 데이터를 조립
**평균 조회 시간: 약 1.88초**

**역정규화 도입 후**
- 조회 전용 MongoDB에서 단일 쿼리로 주문 내역 조회
- 서비스 간 호출 및 분산 조립 로직 제거
**평균 조회 시간: 약 20ms**

➡️ 조회 성능 약 90배 이상 개선
<br><br>


> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - https://curiousjinan.tistory.com/entry/fixing-spring-transactionaleventlistener-after-commit-update-issue#%ED%8A%B8%EB%9E%9C%EC%9E%AD%EC%85%98%EC%9D%98%20%ED%9D%90%EB%A6%84%EA%B3%BC%20%EC%A7%80%EA%B8%88%20%EB%AC%B8%EC%A0%9C%EB%9E%91%20%EB%AC%B4%EC%8A%A8%20%EC%97%B0%EA%B4%80%EC%9D%B4%20%EC%9E%88%EB%8A%94%20%EA%B1%B0%EC%95%BC%3F-1
    - https://curiousjinan.tistory.com/entry/transactional-outbox-pattern-microservices-kafka

