### PR TITLE
[refactor- 14] : aggregateId 기반 멱등성 처리로 Outbox 재발행 중복 저장 문제 해결

### DIFF
--- a/src/main/java/com/personal_project/coupon/order/domain/model/document/OrderSummaryDocument.java
+++ b/src/main/java/com/personal_project/coupon/order/domain/model/document/OrderSummaryDocument.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
@@ -19,7 +20,10 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @NoArgsConstructor
 @Document(collection = "orders_summaries") // MongoDB 컬렉션 이름
-@CompoundIndex(def = "{'memberId': 1, 'orderTime': -1}")
+@CompoundIndexes({ // 여러 복합 인덱스를 선언할 땐 @CompoundIndexes 사용
+        @CompoundIndex(def = "{'memberId': 1, 'orderTime': -1}"),
+        @CompoundIndex(name = "unique_order_idx", def = "{'orderId': 1}", unique = true)
+})
 public class OrderSummaryDocument {
 
     @Id

--- a/src/main/java/com/personal_project/coupon/order/framwork/kafkaadapter/OrderCreatedConsumer.java
+++ b/src/main/java/com/personal_project/coupon/order/framwork/kafkaadapter/OrderCreatedConsumer.java
@@ -1,6 +1,7 @@
 package com.personal_project.coupon.order.framwork.kafkaadapter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.dao.DuplicateKeyException;
 import com.personal_project.coupon.coupon.domain.model.enumeration.DiscountType;
 import com.personal_project.coupon.global.exception.BusinessException;
 import com.personal_project.coupon.global.exception.errorcode.CommonErrorCode;
@@ -56,7 +57,10 @@ public class OrderCreatedConsumer {
                         storeCategory.getName(),
                         brand.getName(),store.getName(), discountType);
 
-        orderSummaryOutputPort.save(orderSummaryDocument);
-
+        try {
+            orderSummaryOutputPort.save(orderSummaryDocument);
+        }catch (DuplicateKeyException e) {
+            log.warn(" 중복 이벤트 감지 - 저장 생략 ");
+        }
     }
 }


### PR DESCRIPTION
> ## 🧩 Outbox 패턴 + Kafka 멱등성 프로듀서 + 재전송 시 중복 문제
    
 ### 문제 상황
- Outbox 패턴을 적용한 이벤트 발행 과정에서, Kafka 전송은 성공했지만 Outbox 테이블의 상태가
READY_TO_PUBLISH(발행준비) 또는 FAILED(실패)로 남는 경우가 발생할 수 있음.
- 이 경우,스케줄러가 해당 Outbox 이벤트를 재전송하면서 동일한 메시지가 Kafka에 중복 발행될 가능성이 존재.
  
 ### Kafka 멱등성 프로듀서 한계
- Kafka는 (PID, Partition, Sequence Number) 조합을 이용해 프로듀서 단에서 중복 메시지 방지를 수행.
- 그러나 애플리케이션 재실행시, 새로운 프로듀서 인스턴스가 생성되며 새로운 PID가 부여되고 시퀀스 넘버가 초기화됨.
- 따라서 브로커 입장에서는 이전과 동일한 메시지라 하더라도 새로운 메시지로 인식되어 멱등성 보장이 불가능함.
<br><br>


> ## ✅ 해결 방안: Consumer 레벨에서 중복 처리
- Kafka의 전달 보장은 At-Least Once Delivery이므로, 중복 수신 가능성을 전제로 Consumer에서 멱등성 처리를 수행해야 함.

 ### 처리 전략
- 이벤트의 고유 식별자(aggregateId(orderId)) 를 기준으로 Unique Index를 설정.
  <img width="708" height="120" alt="image" src="https://github.com/user-attachments/assets/2bcbf8dc-f2e4-49ab-ac9a-00935c2fef23" />
- 동일한 이벤트가 중복 소비될 경우, DB에서 DuplicateKeyException 이 발생하더라도 이를 정상적인 중복 수신으로 간주하고 무시.
  <img width="447" height="122" alt="image" src="https://github.com/user-attachments/assets/202d0bcd-8cf9-4008-bdc3-ca20daaf2a09" />
- 이를 통해 메시지가 여러 번 전달되더라도 단 한 번만 처리된 것과 동일한 효과 (Exactly-Once Processing) 를 보장.






