### PR TITLE
Feat 23/query optimization

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -42,8 +42,7 @@ spring:
         - id: store-internal
           uri: lb://STORESERVER
           predicates:
-            - Path=/internal/menus/**
-            - Path=/internal/stores/**
+            - Path=/internal/menus/**,/internal/stores/**
 
         # ===============================
         # ORDER SERVICE
@@ -51,7 +50,7 @@ spring:
         - id: order-api
           uri: lb://ORDERSERVER
           predicates:
-            - Path=/api/v1/orders/**
+            - Path=/api/v1/orders/**,/api/v1/statistics/**
 
         # ===============================
         # PAYMENT SERVICE (internal only)

--- a/order-service/src/main/java/com/example/orderserver/order/application/inputport/InquiryStatisticsInputPort.java
+++ b/order-service/src/main/java/com/example/orderserver/order/application/inputport/InquiryStatisticsInputPort.java
@@ -1,0 +1,24 @@
+package com.example.orderserver.order.application.inputport;
+
+import com.example.orderserver.order.application.outputport.StatisticsOutputPort;
+import com.example.orderserver.order.application.usecase.InquiryStatisticsUseCase;
+import com.example.orderserver.order.framwork.web.response.MonthlyOrderStatisticsOutPutDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class InquiryStatisticsInputPort implements InquiryStatisticsUseCase {
+    private final StatisticsOutputPort statisticsOutputPort;
+    @Override
+    public List<MonthlyOrderStatisticsOutPutDTO> getMonthlyOrderStatistics(LocalDateTime startDate,
+                                                                           LocalDateTime endDate){
+        return statisticsOutputPort.getMonthlyOrderStatistics(startDate, endDate);
+    }
+
+}

--- a/order-service/src/main/java/com/example/orderserver/order/application/inputport/InquiryStatisticsInputPort.java
+++ b/order-service/src/main/java/com/example/orderserver/order/application/inputport/InquiryStatisticsInputPort.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.List;
 
 @Transactional
@@ -18,7 +20,27 @@ public class InquiryStatisticsInputPort implements InquiryStatisticsUseCase {
     @Override
     public List<MonthlyOrderStatisticsOutPutDTO> getMonthlyOrderStatistics(LocalDateTime startDate,
                                                                            LocalDateTime endDate){
-        return statisticsOutputPort.getMonthlyOrderStatistics(startDate, endDate);
+        List<LocalDateTime[]> monthRanges = splitByMonth(startDate, endDate);
+
+        return monthRanges.parallelStream()
+                .map(range -> statisticsOutputPort.getMonthlyOrderStatistics(range[0], range[1]))
+                .flatMap(List::stream)
+                .sorted((a, b) -> Integer.compare(a.getMonth(), b.getMonth()))
+                .toList();
+    }
+
+    private List<LocalDateTime[]> splitByMonth(LocalDateTime start, LocalDateTime end) {
+        List<LocalDateTime[]> ranges = new ArrayList<>();
+        YearMonth currentYM = YearMonth.from(start);
+        YearMonth endYM = YearMonth.from(end);
+
+        while (!currentYM.isAfter(endYM)) {
+            LocalDateTime monthStart = currentYM.atDay(1).atStartOfDay();
+            LocalDateTime monthEnd = currentYM.atEndOfMonth().atTime(23, 59, 59, 999_999_999);
+            ranges.add(new LocalDateTime[]{monthStart, monthEnd});
+            currentYM = currentYM.plusMonths(1);
+        }
+        return ranges;
     }
 
 }

--- a/order-service/src/main/java/com/example/orderserver/order/application/outputport/StatisticsOutputPort.java
+++ b/order-service/src/main/java/com/example/orderserver/order/application/outputport/StatisticsOutputPort.java
@@ -1,0 +1,12 @@
+package com.example.orderserver.order.application.outputport;
+
+import com.example.orderserver.order.framwork.web.response.MonthlyOrderStatisticsOutPutDTO;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface StatisticsOutputPort {
+
+    List<MonthlyOrderStatisticsOutPutDTO> getMonthlyOrderStatistics(LocalDateTime startDate,
+                                                                    LocalDateTime endDate);
+}

--- a/order-service/src/main/java/com/example/orderserver/order/application/usecase/InquiryStatisticsUseCase.java
+++ b/order-service/src/main/java/com/example/orderserver/order/application/usecase/InquiryStatisticsUseCase.java
@@ -1,0 +1,11 @@
+package com.example.orderserver.order.application.usecase;
+
+import com.example.orderserver.order.framwork.web.response.MonthlyOrderStatisticsOutPutDTO;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface InquiryStatisticsUseCase {
+    List<MonthlyOrderStatisticsOutPutDTO> getMonthlyOrderStatistics(LocalDateTime startDate,
+                                                                    LocalDateTime endDate);
+}

--- a/order-service/src/main/java/com/example/orderserver/order/framwork/web/StatisticsController.java
+++ b/order-service/src/main/java/com/example/orderserver/order/framwork/web/StatisticsController.java
@@ -1,0 +1,31 @@
+package com.example.orderserver.order.framwork.web;
+
+import com.example.common.global.exception.response.SuccessResponse;
+import com.example.orderserver.order.application.usecase.InquiryStatisticsUseCase;
+import com.example.orderserver.order.framwork.web.response.MonthlyOrderStatisticsOutPutDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/statistics")
+public class StatisticsController {
+
+    private final InquiryStatisticsUseCase inquiryStatisticsUseCase;
+
+    @GetMapping("/monthly-order")
+    public SuccessResponse<List<MonthlyOrderStatisticsOutPutDTO>> getMonthlyOrderStatistics(@RequestParam("startDate") String startDateStr,
+                                                                                            @RequestParam("endDate") String endDateStr) {
+
+        LocalDateTime startDate = LocalDate.parse(startDateStr).atStartOfDay();
+        LocalDateTime endDate = LocalDate.parse(endDateStr).atTime(23,59,59);
+
+        List<MonthlyOrderStatisticsOutPutDTO> response =
+                inquiryStatisticsUseCase.getMonthlyOrderStatistics(startDate, endDate);
+        return SuccessResponse.success(response);
+    }
+}

--- a/order-service/src/main/java/com/example/orderserver/order/framwork/web/response/MonthlyOrderStatisticsOutPutDTO.java
+++ b/order-service/src/main/java/com/example/orderserver/order/framwork/web/response/MonthlyOrderStatisticsOutPutDTO.java
@@ -1,0 +1,26 @@
+package com.example.orderserver.order.framwork.web.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MonthlyOrderStatisticsOutPutDTO {
+    private Integer month;
+    private Long totalOrderCnt; //주문개수
+    private Long totalOrderPrice; //주문 총합
+    private Long totalMenuCnt; //메뉴 개수
+    private Long totalMenuQuantity ; //메뉴총합
+
+    public MonthlyOrderStatisticsOutPutDTO mapToDTO(Integer month,Long totalOrderCnt,
+                                                    Long totalOrderPrice,Long totalMenuCnt,
+                                                    Long totalMenuQuantity) {
+        return MonthlyOrderStatisticsOutPutDTO.builder()
+                .month(month)
+                .totalMenuCnt(totalOrderCnt)
+                .totalOrderPrice(totalOrderPrice)
+                .totalMenuCnt(totalMenuCnt)
+                .totalMenuQuantity(totalMenuQuantity)
+                .build();
+    }
+}

--- a/order-service/src/main/java/com/example/orderserver/order/infra/persistence/OrderJpaRepository.java
+++ b/order-service/src/main/java/com/example/orderserver/order/infra/persistence/OrderJpaRepository.java
@@ -1,18 +1,30 @@
 package com.example.orderserver.order.infra.persistence;
 
 import com.example.orderserver.order.domain.model.Order;
+import com.example.orderserver.order.framwork.web.response.MonthlyOrderStatisticsOutPutDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface OrderJpaRepository extends JpaRepository<Order, Long> {
-//    @Query("""
-//            select o from Order o
-//            join fetch o.store s
-//            join fetch s.storeCategory
-//            join fetch s.brand
-//            left join o.couponIssue ci
-//            left join ci.coupon c
-//            where o.id = :orderId and o.member.id = :memberId
-//            """)
-//    public Optional<Order> findOrder(@Param("memberId") Long memberId,
-//                                     @Param("orderId") Long orderId);
+    @Query("""
+        SELECT new com.example.orderserver.order.framwork.web.response.MonthlyOrderStatisticsOutPutDTO(
+            FUNCTION('MONTH', o.orderTime),
+            COUNT(DISTINCT o.id),
+            SUM(o.finalPrice),
+            COUNT(om.menuId),
+            SUM(om.quantity)
+        )
+        FROM Order o
+        JOIN o.orderMenuList om
+        WHERE o.orderTime BETWEEN :startDate AND :endDate
+        GROUP BY FUNCTION('MONTH', o.orderTime)
+        ORDER BY FUNCTION('MONTH', o.orderTime)
+    """)
+    List<MonthlyOrderStatisticsOutPutDTO> getMonthlyOrderStatistics(
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    );
 }

--- a/order-service/src/main/java/com/example/orderserver/order/infra/persistence/StatisticsAdapter.java
+++ b/order-service/src/main/java/com/example/orderserver/order/infra/persistence/StatisticsAdapter.java
@@ -1,0 +1,21 @@
+package com.example.orderserver.order.infra.persistence;
+
+import com.example.orderserver.order.application.outputport.StatisticsOutputPort;
+import com.example.orderserver.order.framwork.web.response.MonthlyOrderStatisticsOutPutDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class StatisticsAdapter implements StatisticsOutputPort {
+    private final OrderJpaRepository orderJpaRepository;
+    @Override
+    public List<MonthlyOrderStatisticsOutPutDTO> getMonthlyOrderStatistics(LocalDateTime startDate,
+                                                                           LocalDateTime endDate){
+        return orderJpaRepository.getMonthlyOrderStatistics(startDate,endDate);
+    }
+
+}


### PR DESCRIPTION
> ##  복잡한 쿼리 최적화

 * 기술 블로그 포스팅 : [1200만건 데이터 복합 인덱스와 커버링 인덱스로 최적화하기](https://velog.io/@wngus4278/1200%EB%A7%8C%EA%B1%B4-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EB%B3%B5%ED%95%A9-%EC%9D%B8%EB%8D%B1%EC%8A%A4%EC%99%80-%EC%BB%A4%EB%B2%84%EB%A7%81-%EC%9D%B8%EB%8D%B1%EC%8A%A4%EB%A1%9C-%EC%B5%9C%EC%A0%81%ED%99%94%ED%95%98%EA%B8%B0)

> ## 🧩 쿼리 최적화 - 복합인덱스/ 커버링 인덱스 사용 

> - CREATE INDEX idx_orders_covering ON orders(order_time, order_id, final_price);
> - CREATE INDEX idx_order_menu_join_covering ON order_menu(order_id, menu_id, quantity);

인덱스를 통해 17 -> 8초로 줄였음.     

> ## 🧩 병렬 스트림 사용

- 병렬 스트림을 통해 8초 -> 3초대로 줄였습니다. 

<img width="729" height="374" alt="image" src="https://github.com/user-attachments/assets/a70343d2-a9ca-4a73-bb30-dfb06e405241" />

